### PR TITLE
Broaden Maven version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
     name: Verify
     uses: maveniverse/parent/.github/workflows/ci.yml@release-19
     with:
-      maven-matrix: '[ "3.9.9" ]'
+      maven-matrix: '[ "3.6.3", "3.8.8", "3.9.9" ]'
       jdk-matrix: '[ "8", "21" ]'
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
     name: Verify
     uses: maveniverse/parent/.github/workflows/ci.yml@release-19
     with:
-      maven-matrix: '[ "3.6.3", "3.8.8", "3.9.9" ]'
+      maven-matrix: '[ "3.8.8", "3.9.9" ]'
       jdk-matrix: '[ "8", "21" ]'
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'

--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/NisseConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/NisseConfiguration.java
@@ -47,6 +47,13 @@ public interface NisseConfiguration {
     Path getCurrentWorkingDirectory();
 
     /**
+     * Returns the path that should be considered "session root directory", never {@code null}.
+     * <p>
+     * Note: this is to support older Maven versions than 3.9.2.
+     */
+    Path getSessionRootDirectory();
+
+    /**
      * Returns {@code true} if property source is active (by default they are active). To disable a source use
      * {@code "nisse.source.$source.active=false"} property (defaults to {@code true}).
      */

--- a/extension3/pom.xml
+++ b/extension3/pom.xml
@@ -68,6 +68,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${version.resolver}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${version.maven}</version>

--- a/extension3/pom.xml
+++ b/extension3/pom.xml
@@ -68,12 +68,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-util</artifactId>
-      <version>${version.resolver}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${version.maven}</version>

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseConfigurationProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseConfigurationProcessor.java
@@ -21,7 +21,6 @@ import javax.inject.Singleton;
 import org.apache.maven.cli.CliRequest;
 import org.apache.maven.cli.configuration.ConfigurationProcessor;
 import org.apache.maven.cli.configuration.SettingsXmlConfigurationProcessor;
-import org.apache.maven.rtinfo.RuntimeInformation;
 import org.eclipse.sisu.Priority;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +35,7 @@ final class NisseConfigurationProcessor implements ConfigurationProcessor {
 
     @Inject
     public NisseConfigurationProcessor(
-            NisseManager nisseManager,
-            SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor) {
+            NisseManager nisseManager, SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor) {
         this.nisseManager = requireNonNull(nisseManager, "nisseManager");
         this.settingsXmlConfigurationProcessor =
                 requireNonNull(settingsXmlConfigurationProcessor, "settingsXmlConfigurationProcessor");

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseConfigurationProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseConfigurationProcessor.java
@@ -33,17 +33,14 @@ final class NisseConfigurationProcessor implements ConfigurationProcessor {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final NisseManager nisseManager;
     private final SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor;
-    private final RuntimeInformation runtimeInformation;
 
     @Inject
     public NisseConfigurationProcessor(
             NisseManager nisseManager,
-            SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor,
-            RuntimeInformation runtimeInformation) {
+            SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor) {
         this.nisseManager = requireNonNull(nisseManager, "nisseManager");
         this.settingsXmlConfigurationProcessor =
                 requireNonNull(settingsXmlConfigurationProcessor, "settingsXmlConfigurationProcessor");
-        this.runtimeInformation = requireNonNull(runtimeInformation, "runtimeInformation");
     }
 
     @Override

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
@@ -27,7 +27,7 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
 
     @Override
-    public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
+    public void afterSessionStart(MavenSession session) throws MavenExecutionException {
         NisseConfiguration configuration = SimpleNisseConfiguration.builder()
                 .withSystemProperties(session.getSystemProperties())
                 .withUserProperties(session.getUserProperties())
@@ -40,6 +40,10 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 logger.info("Nisse property {} configured for inlining", inlinedKey);
             }
         }
+    }
+
+    @Override
+    public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
         try {
             inliner.mayInlinePom(session, session.getProjects());
         } catch (IOException e) {

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
@@ -32,6 +32,8 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .withSystemProperties(session.getSystemProperties())
                 .withUserProperties(session.getUserProperties())
                 .withCurrentWorkingDirectory(Paths.get(session.getRequest().getBaseDirectory()))
+                .withSessionRootDirectory(
+                        session.getRequest().getMultiModuleProjectDirectory().toPath())
                 .build();
         for (String inlinedKey : configuration.getInlinedPropertyKeys()) {
             if (inliner.inlinedKeys(session).add(inlinedKey)) {

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyInliner.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyInliner.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,8 +62,7 @@ final class NissePropertyInliner {
                 if (isAnyKeyPresent(inlinedProperties, pomPath)) {
                     // needs rewrite
                     logger.info(" * {}:{} needs inlining", mavenProject.getGroupId(), mavenProject.getArtifactId());
-                    Path inlinedPomPath = Paths.get(mavenProject.getBuild().getDirectory())
-                            .resolve("inlined-" + pomPath.getFileName());
+                    Path inlinedPomPath = pomPath.getParent().resolve(".inlined-" + pomPath.getFileName());
                     Files.createDirectories(inlinedPomPath.getParent());
                     inline(pomPath, inlinedPomPath, inlinedProperties);
                     mavenProject.setFile(inlinedPomPath.toFile());

--- a/it/extension3-its/src/it/ci-friendly/invoker.properties
+++ b/it/extension3-its/src/it/ci-friendly/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = install -e
+invoker.goals = clean install -e

--- a/it/extension3-its/src/it/configured-inline/invoker.properties
+++ b/it/extension3-its/src/it/configured-inline/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = install -e
+invoker.goals = clean install -e

--- a/it/plugin3-its/src/it/smoke/build.properties
+++ b/it/plugin3-its/src/it/smoke/build.properties
@@ -1,4 +1,3 @@
 # example Nisse property file: it will be read up and injected into user properties
-one='one' på engelsk er en
-two='two' på engelsk er to
-
+one=en
+two=to

--- a/it/plugin3-its/src/it/smoke/invoker.properties
+++ b/it/plugin3-its/src/it/smoke/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = validate help:evaluate -Dexpression=nisse.file.one
+invoker.goals = validate

--- a/it/plugin3-its/src/it/smoke/pom.xml
+++ b/it/plugin3-its/src/it/smoke/pom.xml
@@ -29,6 +29,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>display-property</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>write-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>project.properties</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/it/plugin3-its/src/it/smoke/verify.groovy
+++ b/it/plugin3-its/src/it/smoke/verify.groovy
@@ -1,3 +1,6 @@
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
-assert buildLog.text.contains ('\'one\' på engelsk er en')
+
+File projectProperties = new File(basedir, 'project.properties')
+assert projectProperties.text.contains ('nisse.file.one=en')
+assert projectProperties.text.contains ('nisse.file.two=to')

--- a/plugin3/src/main/java/eu/maveniverse/maven/nisse/plugin3/InjectPropertiesMojo.java
+++ b/plugin3/src/main/java/eu/maveniverse/maven/nisse/plugin3/InjectPropertiesMojo.java
@@ -33,6 +33,10 @@ public class InjectPropertiesMojo extends AbstractMojo {
                 .withSystemProperties(mavenSession.getSystemProperties())
                 .withUserProperties(mavenSession.getUserProperties())
                 .withCurrentWorkingDirectory(Paths.get(mavenSession.getRequest().getBaseDirectory()))
+                .withSessionRootDirectory(mavenSession
+                        .getRequest()
+                        .getMultiModuleProjectDirectory()
+                        .toPath())
                 .build();
         Map<String, String> properties = nisseManager.createProperties(configuration);
         getLog().info("Injecting " + properties.size() + " properties");

--- a/plugin3/src/main/java/eu/maveniverse/maven/nisse/plugin3/InjectPropertiesMojo.java
+++ b/plugin3/src/main/java/eu/maveniverse/maven/nisse/plugin3/InjectPropertiesMojo.java
@@ -4,6 +4,7 @@ import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import eu.maveniverse.maven.nisse.core.NisseManager;
 import eu.maveniverse.maven.nisse.core.internal.SimpleNisseConfiguration;
 import java.nio.file.Paths;
+import java.util.Map;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -33,8 +34,8 @@ public class InjectPropertiesMojo extends AbstractMojo {
                 .withUserProperties(mavenSession.getUserProperties())
                 .withCurrentWorkingDirectory(Paths.get(mavenSession.getRequest().getBaseDirectory()))
                 .build();
-        nisseManager
-                .createProperties(configuration)
-                .forEach((k, v) -> mavenProject.getProperties().setProperty(k, v));
+        Map<String, String> properties = nisseManager.createProperties(configuration);
+        getLog().info("Injecting " + properties.size() + " properties");
+        properties.forEach((k, v) -> mavenProject.getProperties().setProperty(k, v));
     }
 }


### PR DESCRIPTION
Support Maven 3.8.x and Maven 3.9.x. Maven 3.6.x _cannot_ be supported, as it has "fixed set" of allowed CI Friendly expressions, and no way to extend them in sane way.