### PR TITLE
Ability to translate published property keys

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/NisseConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/NisseConfiguration.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.nisse.core;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 public interface NisseConfiguration {
     /**
@@ -64,4 +65,9 @@ public interface NisseConfiguration {
      * {@code "nisse.source.inlinedKeys=key1,key2"} property (defaults to empty collection).
      */
     Collection<String> getInlinedPropertyKeys();
+
+    /**
+     * Returns the {@link PropertyKeyNamingStrategies} to apply to published properties.
+     */
+    BiFunction<PropertySource, String, String> propertyKeyNamingStrategy();
 }

--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/PropertyKeyNamingStrategies.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/PropertyKeyNamingStrategies.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.nisse.core;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * Property key naming strategies.
+ */
+public interface PropertyKeyNamingStrategies extends BiFunction<PropertySource, String, String> {
+    /**
+     * The default naming strategy Nisse applied in existing releases so far.
+     * <p>
+     * It prefixes keys as {@code "nisse." + $source.name + "." + $key}.
+     */
+    static BiFunction<PropertySource, String, String> nisseDefault() {
+        return sourcePrefixed().andThen(s -> NisseConfiguration.PROPERTY_PREFIX + s);
+    }
+
+    /**
+     * Publishes properties as set by source. Based on sources being in use, this may cause key conflicts with
+     * undefined behaviour.
+     */
+    static BiFunction<PropertySource, String, String> identity() {
+        return (source, key) -> key;
+    }
+
+    /**
+     * Prefixes property keys with specified static prefix. Based on sources being in use, this may cause key
+     * conflicts with undefined behaviour.
+     */
+    static BiFunction<PropertySource, String, String> prefixed(String staticPrefix) {
+        requireNonNull(staticPrefix, "staticPrefix");
+        return (source, key) -> staticPrefix + key;
+    }
+
+    /**
+     * Prefixes property keys with source name making them unique.
+     */
+    static BiFunction<PropertySource, String, String> sourcePrefixed() {
+        return (source, key) -> source.getName() + "." + key;
+    }
+
+    /**
+     * Translates properties using provided translation table, if key not found, uses fallback strategy.
+     * <p>
+     * This function applies {@code lookup} strategy and using result performs a lookup on provided {@code translation}
+     * map. If result is non-null, will be used, otherwise {@code fallback} strategy is used.
+     */
+    static BiFunction<PropertySource, String, String> translated(
+            Map<String, String> translation,
+            BiFunction<PropertySource, String, String> lookup,
+            BiFunction<PropertySource, String, String> fallback) {
+        requireNonNull(translation, "translation");
+        requireNonNull(lookup, "lookup");
+        requireNonNull(fallback, "fallback");
+        return (source, key) -> {
+            String lookupKey = lookup.apply(source, key);
+            String translated = translation.get(lookupKey);
+            if (translated == null) {
+                translated = fallback.apply(source, key);
+            }
+            return translated;
+        };
+    }
+}

--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/internal/SimpleNisseManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/internal/SimpleNisseManager.java
@@ -15,6 +15,7 @@ import eu.maveniverse.maven.nisse.core.PropertySource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -32,12 +33,13 @@ class SimpleNisseManager implements NisseManager {
     @Override
     public Map<String, String> createProperties(NisseConfiguration configuration) {
         requireNonNull(configuration, "configuration");
+        BiFunction<PropertySource, String, String> propertyKeyNamingStrategy =
+                configuration.propertyKeyNamingStrategy();
         HashMap<String, String> properties = new HashMap<>();
         for (PropertySource source : this.sources) {
             if (configuration.isPropertySourceActive(source)) {
                 source.getProperties(configuration)
-                        .forEach((key, value) -> properties.put(
-                                NisseConfiguration.PROPERTY_PREFIX + source.getName() + "." + key, value));
+                        .forEach((key, value) -> properties.put(propertyKeyNamingStrategy.apply(source, key), value));
             }
         }
         return properties;

--- a/core/src/test/java/eu/maveniverse/maven/nisse/core/internal/SimpleNisseManagerTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/nisse/core/internal/SimpleNisseManagerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import eu.maveniverse.maven.nisse.core.PropertySource;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 public class SimpleNisseManagerTest {
     @Test
-    void smoke() {
+    void smoke() throws IOException {
         Map<String, String> m1 = new HashMap<>();
         m1.put("one", "en");
         m1.put("two", "to");

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
@@ -28,17 +28,22 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     @Override
     public void afterSessionStart(MavenSession session) throws MavenExecutionException {
-        NisseConfiguration configuration = SimpleNisseConfiguration.builder()
-                .withSystemProperties(session.getSystemProperties())
-                .withUserProperties(session.getUserProperties())
-                .withCurrentWorkingDirectory(Paths.get(session.getRequest().getBaseDirectory()))
-                .withSessionRootDirectory(
-                        session.getRequest().getMultiModuleProjectDirectory().toPath())
-                .build();
-        for (String inlinedKey : configuration.getInlinedPropertyKeys()) {
-            if (inliner.inlinedKeys(session).add(inlinedKey)) {
-                logger.info("Nisse property {} configured for inlining", inlinedKey);
+        try {
+            NisseConfiguration configuration = SimpleNisseConfiguration.builder()
+                    .withSystemProperties(session.getSystemProperties())
+                    .withUserProperties(session.getUserProperties())
+                    .withCurrentWorkingDirectory(Paths.get(session.getRequest().getBaseDirectory()))
+                    .withSessionRootDirectory(session.getRequest()
+                            .getMultiModuleProjectDirectory()
+                            .toPath())
+                    .build();
+            for (String inlinedKey : configuration.getInlinedPropertyKeys()) {
+                if (inliner.inlinedKeys(session).add(inlinedKey)) {
+                    logger.info("Nisse property {} configured for inlining", inlinedKey);
+                }
             }
+        } catch (IOException e) {
+            throw new MavenExecutionException("Error while creating Nisse configuration", e);
         }
     }
 

--- a/it/extension3-its/src/it/translated/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/translated/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/translated/.mvn/maven.config
+++ b/it/extension3-its/src/it/translated/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.file.name=${session.rootDirectory}/build.properties

--- a/it/extension3-its/src/it/translated/.mvn/nisse-translation.properties
+++ b/it/extension3-its/src/it/translated/.mvn/nisse-translation.properties
@@ -1,0 +1,9 @@
+os.name=os.detected.name
+os.arch=os.detected.arch
+os.bitness=os.detected.bitness
+os.version=os.detected.version
+os.version.major=os.detected.version.major
+os.version.minor=os.detected.version.minor
+os.classifier=os.detected.classifier
+os.release=os.detected.release
+os.release.version=os.detected.release.version

--- a/it/extension3-its/src/it/translated/invoker.properties
+++ b/it/extension3-its/src/it/translated/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -X -Dnisse.dump

--- a/it/extension3-its/src/it/translated/pom.xml
+++ b/it/extension3-its/src/it/translated/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.smoke</groupId>
+    <artifactId>smoke</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/translated/verify.groovy
+++ b/it/extension3-its/src/it/translated/verify.groovy
@@ -1,0 +1,6 @@
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+assert buildLog.text.contains ('os.detected.name')
+assert buildLog.text.contains ('os.detected.arch')
+assert buildLog.text.contains ('os.detected.bitness')
+assert buildLog.text.contains ('os.detected.classifier')

--- a/plugin3/src/main/java/eu/maveniverse/maven/nisse/plugin3/InjectPropertiesMojo.java
+++ b/plugin3/src/main/java/eu/maveniverse/maven/nisse/plugin3/InjectPropertiesMojo.java
@@ -3,13 +3,13 @@ package eu.maveniverse.maven.nisse.plugin3;
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import eu.maveniverse.maven.nisse.core.NisseManager;
 import eu.maveniverse.maven.nisse.core.internal.SimpleNisseConfiguration;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 
@@ -28,18 +28,23 @@ public class InjectPropertiesMojo extends AbstractMojo {
     private NisseManager nisseManager;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        NisseConfiguration configuration = SimpleNisseConfiguration.builder()
-                .withSystemProperties(mavenSession.getSystemProperties())
-                .withUserProperties(mavenSession.getUserProperties())
-                .withCurrentWorkingDirectory(Paths.get(mavenSession.getRequest().getBaseDirectory()))
-                .withSessionRootDirectory(mavenSession
-                        .getRequest()
-                        .getMultiModuleProjectDirectory()
-                        .toPath())
-                .build();
-        Map<String, String> properties = nisseManager.createProperties(configuration);
-        getLog().info("Injecting " + properties.size() + " properties");
-        properties.forEach((k, v) -> mavenProject.getProperties().setProperty(k, v));
+    public void execute() throws MojoExecutionException {
+        try {
+            NisseConfiguration configuration = SimpleNisseConfiguration.builder()
+                    .withSystemProperties(mavenSession.getSystemProperties())
+                    .withUserProperties(mavenSession.getUserProperties())
+                    .withCurrentWorkingDirectory(
+                            Paths.get(mavenSession.getRequest().getBaseDirectory()))
+                    .withSessionRootDirectory(mavenSession
+                            .getRequest()
+                            .getMultiModuleProjectDirectory()
+                            .toPath())
+                    .build();
+            Map<String, String> properties = nisseManager.createProperties(configuration);
+            getLog().info("Injecting " + properties.size() + " properties");
+            properties.forEach((k, v) -> mavenProject.getProperties().setProperty(k, v));
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error while creating Nisse configuration", e);
+        }
     }
 }

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -1,11 +1,12 @@
 package eu.maveniverse.maven.nisse.source.jgit;
 
 import eu.maveniverse.maven.nisse.core.internal.SimpleNisseConfiguration;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class JGitPropertySourceTest {
     @Test
-    void smoke() {
+    void smoke() throws IOException {
         new JGitPropertySource()
                 .getProperties(SimpleNisseConfiguration.builder().build())
                 .forEach((k, v) -> System.out.println(k + " = " + v));

--- a/sources/mvn-source/src/main/java/eu/maveniverse/maven/nisse/source/mvn/MvnPropertySource.java
+++ b/sources/mvn-source/src/main/java/eu/maveniverse/maven/nisse/source/mvn/MvnPropertySource.java
@@ -37,8 +37,6 @@ public class MvnPropertySource implements PropertySource {
     private static final String VERSION_PATCH = "patch";
     private static final String VERSION_QUALIFIER = "qualifier";
 
-    private static final String UNKNOWN = "unknown";
-
     @Override
     public String getName() {
         return NAME;

--- a/sources/mvn-source/src/test/java/eu/maveniverse/maven/nisse/source/mvn/MvnPropertySourceTest.java
+++ b/sources/mvn-source/src/test/java/eu/maveniverse/maven/nisse/source/mvn/MvnPropertySourceTest.java
@@ -1,6 +1,7 @@
 package eu.maveniverse.maven.nisse.source.mvn;
 
 import eu.maveniverse.maven.nisse.core.internal.SimpleNisseConfiguration;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 public class MvnPropertySourceTest {
     @Test
-    void smoke() {
+    void smoke() throws IOException {
         Map<String, String> up = new HashMap<>();
 
         up.clear();

--- a/sources/os-source/src/test/java/eu/maveniverse/maven/nisse/source/osdetector/OsDetectorPropertySourceTest.java
+++ b/sources/os-source/src/test/java/eu/maveniverse/maven/nisse/source/osdetector/OsDetectorPropertySourceTest.java
@@ -1,11 +1,12 @@
 package eu.maveniverse.maven.nisse.source.osdetector;
 
 import eu.maveniverse.maven.nisse.core.internal.SimpleNisseConfiguration;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class OsDetectorPropertySourceTest {
     @Test
-    void smoke() {
+    void smoke() throws IOException {
         new OsDetectorPropertySource()
                 .getProperties(SimpleNisseConfiguration.builder().build())
                 .forEach((k, v) -> System.out.println(k + " = " + v));


### PR DESCRIPTION
If you have file `.mvn/nisse-translation.properties` if will be picked up and used to translate published propery keys.

The extension3-its new IT `translated` shows how to make Nisse a drop in replacement for https://github.com/trustin/os-maven-plugin