### PR TITLE
Tolerate Develocity

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
@@ -58,9 +58,9 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
         } catch (Exception e) {
             // ignore; this means we were invoked outside of session
             if (logger.isDebugEnabled()) {
-                logger.warn("overwriteModelProperties: failed, called out of session?", e);
+                logger.warn("NisseModelVersionProcessor.overwriteModelProperties: failed, called out of session?", e);
             } else {
-                logger.warn("overwriteModelProperties: failed, called out of session?");
+                logger.warn("NisseModelVersionProcessor.overwriteModelProperties: failed, called out of session?");
             }
         }
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
@@ -19,11 +19,14 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.interpolation.ModelVersionProcessor;
 import org.eclipse.sisu.Priority;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 @Named
 @Priority(200)
 final class NisseModelVersionProcessor implements ModelVersionProcessor {
+    private final Logger logger = LoggerFactory.getLogger(NisseModelVersionProcessor.class);
     private final Provider<MavenSession> sessionProvider;
     private final NissePropertyInliner inliner;
 
@@ -46,10 +49,19 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
 
     @Override
     public void overwriteModelProperties(Properties modelProperties, ModelBuildingRequest request) {
-        MavenSession session = this.sessionProvider.get();
-        for (String inlinedKey : inliner.inlinedKeys(session)) {
-            modelProperties.setProperty(
-                    inlinedKey, session.getRequest().getUserProperties().getProperty(inlinedKey));
+        try {
+            MavenSession session = this.sessionProvider.get();
+            for (String inlinedKey : inliner.inlinedKeys(session)) {
+                modelProperties.setProperty(
+                        inlinedKey, session.getRequest().getUserProperties().getProperty(inlinedKey));
+            }
+        } catch (Exception e) {
+            // ignore; this means we were invoked outside of session
+            if (logger.isDebugEnabled()) {
+                logger.warn("overwriteModelProperties: failed, called out of session?", e);
+            } else {
+                logger.warn("overwriteModelProperties: failed, called out of session?");
+            }
         }
     }
 }

--- a/it/extension3-its/src/it/develocity/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/develocity/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.23.2</version>
+    </extension>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/develocity/.mvn/maven.config
+++ b/it/extension3-its/src/it/develocity/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.compat.osDetector

--- a/it/extension3-its/src/it/develocity/invoker.properties
+++ b/it/extension3-its/src/it/develocity/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -V validate

--- a/it/extension3-its/src/it/develocity/pom.xml
+++ b/it/extension3-its/src/it/develocity/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.smoke</groupId>
+    <artifactId>smoke</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/develocity/verify.groovy
+++ b/it/extension3-its/src/it/develocity/verify.groovy
@@ -1,0 +1,5 @@
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+
+// Scope exception
+assert !buildLog.text.contains('com.google.inject.OutOfScopeException: Cannot access session scope outside of a scoping block')


### PR DESCRIPTION
The Develocity extension seems fiddles with model builder outside of Maven session, causing issues for Nisse. Tolerate it. OTOH, Develocity does some strange things, like going over `/sys` and `/proc` and who knows what else... is weird.

Based on https://github.com/maveniverse/nisse/pull/53 and supersedes it.

Nisse when used with Develocity will log this:
```
[WARNING] NisseModelVersionProcessor.overwriteModelProperties: failed, called out of session?
```
In debug mode -X will spit stack trace as well.