### PR TITLE
Bug: align mvn3 and mvn4 ext

### DIFF
--- a/extension4/src/main/java/eu/maveniverse/maven/nisse/extension4/internal/NissePropertyContributor.java
+++ b/extension4/src/main/java/eu/maveniverse/maven/nisse/extension4/internal/NissePropertyContributor.java
@@ -53,7 +53,7 @@ final class NissePropertyContributor implements PropertyContributor {
             if (Boolean.parseBoolean(protoSession.getUserProperties().getOrDefault("nisse.dump", "false"))) {
                 nisseProperties.forEach((k, v) -> logger.info("{}={}", k, v));
             }
-            result.putAll(nisseProperties);
+            nisseProperties.forEach(result::putIfAbsent);
             return result;
         } catch (IOException e) {
             throw new UncheckedIOException("Error while creating Nisse configuration", e);


### PR DESCRIPTION
Always put if absent, as that lets user override any Nisse property by using -D on CLI.

mvn3 ext did it right, mvn4 ext pushed always.