### PR TITLE
Emit JGit commit date as ISO8601 date

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.nisse.source.jgit;
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import eu.maveniverse.maven.nisse.core.PropertySource;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -50,6 +51,8 @@ public class JGitPropertySource implements PropertySource {
     private static final String JGIT_COMMIT = "commit";
 
     private static final String JGIT_DATE = "date";
+
+    private static final String JGIT_DATE_ISO_8601 = "dateIso8601";
 
     private static final String JGIT_AUTHOR = "author";
 
@@ -112,15 +115,20 @@ public class JGitPropertySource implements PropertySource {
                 RevCommit lastCommit = getLastCommit(repository);
 
                 result.put(JGIT_COMMIT, lastCommit.getName());
+                Instant commitTime = Instant.ofEpochSecond(lastCommit.getCommitTime());
                 result.put(
                         JGIT_DATE,
                         ZonedDateTime.ofInstant(
-                                        Instant.ofEpochSecond(lastCommit.getCommitTime()),
+                                        commitTime,
                                         lastCommit
                                                 .getAuthorIdent()
                                                 .getTimeZone()
                                                 .toZoneId())
                                 .format(DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss yyyy Z")));
+                result.put(
+                        JGIT_DATE_ISO_8601,
+                        ZonedDateTime.ofInstant(commitTime, ZoneId.of("UTC"))
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")));
                 result.put(
                         JGIT_COMMITTER,
                         lastCommit.getCommitterIdent().toExternalString().split(">")[0] + ">");


### PR DESCRIPTION
This adds new property, the git commit date but
formatted as ISO8601.