### PR TITLE
Fix version hint functionality and date format locale issues

### DIFF
--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-custom/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-custom/verify.groovy
@@ -14,8 +14,8 @@ assert matcher.find() : "Version information not found in log file"
 // Extract the version from the matched group
 def actualVersion = matcher[0][1]
 
-// Should use the highest version hint tag with custom pattern (3.2.0)
+// Should use the highest version hint tag with custom pattern (3.2.0) and add SNAPSHOT since we're ahead
 // The 5.0.0-SNAPSHOT tag should be ignored because it doesn't match "hint-${version}" pattern
-def expectedVersion = '3.2.0'
+def expectedVersion = '3.2.0-SNAPSHOT'
 
 assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'"

--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-snapshot/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-snapshot/verify.groovy
@@ -14,7 +14,7 @@ assert matcher.find() : "Version information not found in log file"
 // Extract the version from the matched group
 def actualVersion = matcher[0][1]
 
-// Should use the highest version hint tag (4.2.0)
-def expectedVersion = '4.2.0'
+// Should use the highest version hint tag (4.2.0) and add SNAPSHOT since we're ahead
+def expectedVersion = '4.2.0-SNAPSHOT'
 
 assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'"

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -31,7 +31,9 @@ public class JGitPropertySourceTest {
             System.out.println("Default date format: " + dateValue);
             // Default format should match: EEE MMM dd HH:mm:ss yyyy Z
             // Example: Mon May 27 18:20:45 2024 +0200
-            assertTrue(dateValue.matches("\\w{3} \\w{3} \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4} [+-]\\d{4}"));
+            assertTrue(
+                    dateValue.matches("\\w{3} \\w{3} \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4} [+-]\\d{4}"),
+                    "Expected date format 'EEE MMM dd HH:mm:ss yyyy Z' but got: " + dateValue);
         }
     }
 
@@ -108,7 +110,9 @@ public class JGitPropertySourceTest {
             String dateValue = properties.get("date");
             System.out.println("Fallback date format: " + dateValue);
             // Should fall back to default git format
-            assertTrue(dateValue.matches("\\w{3} \\w{3} \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4} [+-]\\d{4}"));
+            assertTrue(
+                    dateValue.matches("\\w{3} \\w{3} \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4} [+-]\\d{4}"),
+                    "Expected fallback date format 'EEE MMM dd HH:mm:ss yyyy Z' but got: " + dateValue);
         }
     }
 


### PR DESCRIPTION
- Fix version hint processing to correctly add SNAPSHOT qualifier
- Modify findHighestVersionFromHints to preserve original version strings
- Apply mayAddSnapshotQualifier to version hints as intended
- Fix date formatting to use English locale consistently
- Update test assertions to provide better error messages

Version hints now work as designed: tags matching the hint pattern are treated as if the previous commit was tagged with that version, and SNAPSHOT qualifier is added when ahead of that commit.