### PR TITLE
Fix version hint vs git history comparison (issue #99)

### DIFF
--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/.mvn/maven.config
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.jgit.dynamicVersion=true

--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/invoker.properties
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = clean validate
+invoker.debug = true

--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/pom.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-dynamic-versioning-version-hint-vs-release-tags</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>version-hint-vs-release-tags-test</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/setup.groovy
@@ -1,0 +1,39 @@
+void exec(String command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git init')
+exec('git config user.email "you@example.com"')
+exec('git config user.name "Your Name"')
+
+exec('git add test.txt')
+exec('git commit -m initial-commit')
+
+// Create an old version hint tag (like the issue describes: 0.9.2-SNAPSHOT from a year ago)
+exec('git tag 0.9.2-SNAPSHOT')
+
+// Add more commits to simulate time passing
+testFile << '\nmore content'
+exec('git add test.txt')
+exec('git commit -m second-commit')
+
+testFile << '\neven more content'
+exec('git add test.txt')
+exec('git commit -m third-commit')
+
+// Create a much newer release tag (like the issue describes: 0.13.0 is the latest)
+exec('git tag 0.13.0')
+
+// Add one more commit to move HEAD away from the release tag
+testFile << '\nfinal content'
+exec('git add test.txt')
+exec('git commit -m fourth-commit')
+
+// List all tags for debugging
+exec('git tag')

--- a/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-version-hint-vs-release-tags/verify.groovy
@@ -1,0 +1,25 @@
+// check that property was set
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+// Read the log file
+def logContent = mavenLogFile.text
+
+// Define a pattern to match the version output
+def versionPattern = /\$\{nisse.jgit.dynamicVersion\}=(.+)/
+def matcher = (logContent =~ versionPattern)
+assert matcher.find() : "Version information not found in log file"
+
+// Extract the version from the matched group
+def actualVersion = matcher[0][1]
+
+// Should use the higher release tag version (0.13.1-1-SNAPSHOT) instead of the old hint tag (0.9.2-SNAPSHOT)
+// The version should be 0.13.1-1-SNAPSHOT because:
+// - 0.13.0 is the latest release tag
+// - We're 1 commit ahead of it, so patch gets incremented to 0.13.1
+// - Build number is 1 (commits ahead)
+// - SNAPSHOT qualifier is added because we're ahead
+def expectedVersion = '0.13.1-1-SNAPSHOT'
+
+assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'. The old version hint tag (0.9.2-SNAPSHOT) should not take precedence over the newer release tag (0.13.0)."


### PR DESCRIPTION
## Problem

Fixes #99 - Version hint tags were taking absolute priority over git history, even when git history contained higher version numbers. This caused issues where old version hint tags (e.g., `0.9.2-SNAPSHOT` from a year ago) would override newer release tags (e.g., `0.13.0`).

## Solution

Implemented intelligent version comparison logic that:

### For Default Pattern (`${version}-SNAPSHOT`):
- Compares version numbers between version hints and git history using semantic versioning
- Uses the higher version number
- If no regular release tags exist, uses version hint directly
- Prevents double-counting by filtering version hint tags from git history

### For Custom Patterns (e.g., `hint-${version}`):
- Preserves existing behavior where version hints take priority
- Only considers tags matching the custom pattern

## Changes Made

### Core Implementation
- **`JGitPropertySource.java`**: 
  - Updated `getVersionInformation()` with intelligent version comparison
  - Added `isVersionHintTag()` method for proper pattern matching
  - Modified `getVersionedTagsForCommit()` to filter version hint tags from git history
  - Added logic to handle custom patterns differently from default patterns

### Tests
- **Unit Tests**: Added comprehensive tests for version comparison and pattern matching
- **Integration Test**: Created `it-dynamic-versioning-version-hint-vs-release-tags` that reproduces the exact scenario from issue #99

## Verification

- ✅ All existing tests pass (17/17 integration tests successful)
- ✅ New unit tests verify version comparison logic
- ✅ New integration test confirms end-to-end fix
- ✅ Full build successful with proper formatting
- ✅ Backward compatibility maintained

## Example

**Before Fix:**
- Version hint: `0.9.2-SNAPSHOT` (old)
- Git history: `0.13.0` (newer)
- Result: `0.9.2-SNAPSHOT` ❌

**After Fix:**
- Version hint: `0.9.2-SNAPSHOT` (old)
- Git history: `0.13.0` (newer)
- Result: `0.13.1-1-SNAPSHOT` ✅ (based on higher git history version)

The fix ensures version hints work as intended - providing future versions that haven't been tagged yet, without overriding existing higher-version release tags.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author