### PR TITLE
Fix: Nested invocations are not possible

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/NisseConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/NisseConfiguration.java
@@ -31,6 +31,16 @@ public interface NisseConfiguration {
     String COMPAT_OS_DETECTOR = PROPERTY_PREFIX + "compat.osDetector";
 
     /**
+     * The key to use to store this instance in session.
+     */
+    String CONFIGURATION_INSTANCE_KEY = PROPERTY_PREFIX + "configurationInstance";
+
+    /**
+     * Inliner config: Key to suppress inliner cleanup. To suppress, set this property to {@code true}.
+     */
+    String CONFIGURATION_INLINER_SUPPRESS_CLEANUP = PROPERTY_PREFIX + "inliner.suppressCleanup";
+
+    /**
      * Returns immutable map of session effective system properties, never {@code null}.
      */
     Map<String, String> getSystemProperties();

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseLifecycleParticipant.java
@@ -58,6 +58,7 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     logger.info("Nisse property {} configured for inlining", inlinedKey);
                 }
             }
+            session.getRepositorySession().getData().set(NisseConfiguration.CONFIGURATION_INSTANCE_KEY, configuration);
         } catch (IOException e) {
             throw new MavenExecutionException("Error while creating Nisse configuration", e);
         }
@@ -66,7 +67,8 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
         try {
-            inliner.mayInlinePom(session, session.getProjects());
+            inliner.mayInlinePom(session, session.getProjects(), (NisseConfiguration)
+                    session.getRepositorySession().getData().get(NisseConfiguration.CONFIGURATION_INSTANCE_KEY));
         } catch (IOException e) {
             throw new MavenExecutionException("Nisse failed to inline", e);
         }
@@ -75,7 +77,8 @@ class NisseLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     @Override
     public void afterSessionEnd(MavenSession session) throws MavenExecutionException {
         try {
-            inliner.cleanup(session, session.getProjects());
+            inliner.cleanup(session, session.getProjects(), (NisseConfiguration)
+                    session.getRepositorySession().getData().get(NisseConfiguration.CONFIGURATION_INSTANCE_KEY));
         } catch (IOException e) {
             throw new MavenExecutionException("Nisse failed to inline", e);
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyInliner.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyInliner.java
@@ -30,9 +30,16 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @Named
 final class NissePropertyInliner {
-    private static final String INLINED_POM_PATH_KEY = NissePropertyInliner.class.getName() + ".inlined";
+    /**
+     * Session data store {@code Set<Path>} that holds all the POM paths that have been inlined, and need cleanup.
+     */
+    private static final String INLINED_POM_PATHS_KEY = NissePropertyInliner.class.getName() + ".inlined";
 
+    /**
+     * Session data stored {@code Set<String>} that holds those keys that cause that POM needs to be inlined.
+     */
     private static final String NEEDS_INLINING_COLLECTION = NisseConfiguration.PROPERTY_PREFIX + "needs-inlining";
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @SuppressWarnings("unchecked")
@@ -46,7 +53,9 @@ final class NissePropertyInliner {
         return inlinedKeys;
     }
 
-    void mayInlinePom(MavenSession session, Collection<MavenProject> mavenProjects) throws IOException {
+    void mayInlinePom(
+            MavenSession session, Collection<MavenProject> mavenProjects, NisseConfiguration nisseConfiguration)
+            throws IOException {
         Collection<String> inlinedKeys = inlinedKeys(session);
         if (!inlinedKeys.isEmpty()) {
             Map<String, String> inlinedProperties = new HashMap<>();
@@ -65,7 +74,7 @@ final class NissePropertyInliner {
                     // needs rewrite
                     logger.info(" * {}:{} needs inlining", mavenProject.getGroupId(), mavenProject.getArtifactId());
                     Path inlinedPomPath = pomPath.getParent().resolve(".inlined-" + pomPath.getFileName());
-                    session.getRepositorySession().getData().set(INLINED_POM_PATH_KEY, inlinedPomPath);
+                    inlinedPoms(session).add(inlinedPomPath);
                     inline(pomPath, inlinedPomPath, inlinedProperties);
                     mavenProject.setPomFile(inlinedPomPath.toFile());
                 }
@@ -75,11 +84,27 @@ final class NissePropertyInliner {
         }
     }
 
-    void cleanup(MavenSession session, Collection<MavenProject> mavenProjects) throws IOException {
-        Path inlinedPom = (Path) session.getRepositorySession().getData().get(INLINED_POM_PATH_KEY);
-        if (inlinedPom != null) {
-            Files.deleteIfExists(inlinedPom);
+    void cleanup(MavenSession session, Collection<MavenProject> mavenProjects, NisseConfiguration nisseConfiguration)
+            throws IOException {
+        if (Boolean.parseBoolean(nisseConfiguration
+                .getConfiguration()
+                .getOrDefault(NisseConfiguration.CONFIGURATION_INLINER_SUPPRESS_CLEANUP, Boolean.FALSE.toString()))) {
+            logger.info("Nisse property inliner cleanup is suppressed by configuration");
+            return;
+        } else {
+            Set<Path> inlinedPoms = inlinedPoms(session);
+            logger.info("Nisse property inliner cleanup: {}", inlinedPoms);
+            for (Path inlinedPom : inlinedPoms) {
+                Files.deleteIfExists(inlinedPom);
+            }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Path> inlinedPoms(MavenSession session) {
+        return (Set<Path>) session.getRepositorySession()
+                .getData()
+                .computeIfAbsent(INLINED_POM_PATHS_KEY, ConcurrentHashMap::newKeySet);
     }
 
     private boolean isAnyKeyPresent(Map<String, String> inlinedProperties, Path file) throws IOException {
@@ -111,5 +136,6 @@ final class NissePropertyInliner {
                 Files.lines(sourcePom, StandardCharsets.UTF_8).map(replacer)) {
             Files.write(targetPom, lines.collect(Collectors.toList()), StandardCharsets.UTF_8);
         }
+        logger.debug("Nisse property inliner inlined: {} -> {}", sourcePom, targetPom);
     }
 }

--- a/it/extension3-its/src/it/multi-module-inline/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/multi-module-inline/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/multi-module-inline/.mvn/maven.config
+++ b/it/extension3-its/src/it/multi-module-inline/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.file.name=${session.rootDirectory}/build.properties

--- a/it/extension3-its/src/it/multi-module-inline/build.properties
+++ b/it/extension3-its/src/it/multi-module-inline/build.properties
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# example Nisse property file: it will be read up and injected into user properties
+version=1.2.3

--- a/it/extension3-its/src/it/multi-module-inline/invoker.properties
+++ b/it/extension3-its/src/it/multi-module-inline/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = -V package

--- a/it/extension3-its/src/it/multi-module-inline/mod1/pom.xml
+++ b/it/extension3-its/src/it/multi-module-inline/mod1/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.nisse.it.mmi</groupId>
+        <artifactId>multi-module-inline</artifactId>
+        <version>${nisse.file.version}</version>
+    </parent>
+
+    <artifactId>mod1</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/multi-module-inline/mod2/pom.xml
+++ b/it/extension3-its/src/it/multi-module-inline/mod2/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.nisse.it.mmi</groupId>
+        <artifactId>multi-module-inline</artifactId>
+        <version>${nisse.file.version}</version>
+    </parent>
+
+    <artifactId>mod2</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/multi-module-inline/pom.xml
+++ b/it/extension3-its/src/it/multi-module-inline/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.mmi</groupId>
+    <artifactId>multi-module-inline</artifactId>
+    <version>${nisse.file.version}</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>mod1</module>
+        <module>mod2</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/multi-module-inline/verify.groovy
+++ b/it/extension3-its/src/it/multi-module-inline/verify.groovy
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+assert buildLog.text.contains ('[INFO]  * eu.maveniverse.maven.nisse.it.mmi:multi-module-inline needs inlining')
+assert buildLog.text.contains ('[INFO]  * eu.maveniverse.maven.nisse.it.mmi:mod1 needs inlining')
+assert buildLog.text.contains ('[INFO]  * eu.maveniverse.maven.nisse.it.mmi:mod2 needs inlining')


### PR DESCRIPTION
## Problem

Nisse's POM property inliner creates temporary `.inlined-pom.xml` files where placeholders like `${nisse.file.version}` are replaced with resolved values. After the build, these temporary files are cleaned up.

However, only a single inlined POM path was tracked in the session data. In a multi-module project, each module's inlined POM overwrote the previous one, so only the last module's temporary file got cleaned up — the rest were left behind as orphans.

## Changes

- Track all inlined POM paths in a `Set<Path>` instead of a single `Path`, so cleanup deletes all of them
- Store the `NisseConfiguration` instance in session data so it can be passed to the inliner and cleanup methods
- Add a `nisse.inliner.suppressCleanup` config option to skip deleting inlined files (useful for debugging)
- Add a multi-module integration test (parent + 2 child modules) that verifies all POMs are inlined