### PR TITLE
Add `branchName` support

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -35,6 +35,7 @@ import org.eclipse.aether.version.VersionScheme;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -289,7 +290,7 @@ public class JGitPropertySource implements PropertySource {
             return Optional.empty();
         }
         return git.branchList().call().stream()
-                .filter(ref -> head.equals(ref.getObjectId()))
+                .filter(ref -> head.equals(ref.getObjectId()) && !Constants.HEAD.equals(ref.getName()))
                 .findFirst();
     }
 

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -224,7 +224,7 @@ public class JGitPropertySource implements PropertySource {
                             lastCommit.getAuthorIdent().toExternalString().split(">")[0] + ">");
                     result.put(JGIT_CLEAN, Boolean.toString(isClean(git)));
 
-                    Optional<Ref> localBranch = localBranch(git);
+                    Optional<Ref> localBranch = localBranch(git, head);
                     localBranch
                             .map(r -> r.getName().replace("refs/heads/", ""))
                             .ifPresent(branchName -> result.put(JGIT_BRANCH_NAME, branchName));
@@ -284,15 +284,12 @@ public class JGitPropertySource implements PropertySource {
         return git.status().call().isClean();
     }
 
-    private Optional<Ref> localBranch(Git git) throws GitAPIException {
+    private Optional<Ref> localBranch(Git git, ObjectId head) throws GitAPIException {
+        if (head == null) {
+            return Optional.empty();
+        }
         return git.branchList().call().stream()
-                .filter(ref -> {
-                    try {
-                        return ref.getObjectId().equals(git.getRepository().resolve("HEAD"));
-                    } catch (IOException e) {
-                        return false;
-                    }
-                })
+                .filter(ref -> head.equals(ref.getObjectId()))
                 .findFirst();
     }
 

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -66,6 +66,8 @@ public class JGitPropertySource implements PropertySource {
 
     private static final String JGIT_CLEAN = "clean";
 
+    private static final String JGIT_BRANCH_NAME = "branchName";
+
     /**
      * Specify the length for the short commit id.
      */
@@ -221,6 +223,12 @@ public class JGitPropertySource implements PropertySource {
                             JGIT_AUTHOR,
                             lastCommit.getAuthorIdent().toExternalString().split(">")[0] + ">");
                     result.put(JGIT_CLEAN, Boolean.toString(isClean(git)));
+
+                    Optional<Ref> localBranch = localBranch(git);
+                    localBranch
+                            .map(r -> r.getName().replace("refs/heads/", ""))
+                            .ifPresent(branchName -> result.put(JGIT_BRANCH_NAME, branchName));
+
                     if (Boolean.parseBoolean(configuration
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION, DEFAULT_DYNAMIC_VERSION))) {
@@ -274,6 +282,18 @@ public class JGitPropertySource implements PropertySource {
 
     private boolean isClean(Git git) throws GitAPIException {
         return git.status().call().isClean();
+    }
+
+    private Optional<Ref> localBranch(Git git) throws GitAPIException {
+        return git.branchList().call().stream()
+                .filter(ref -> {
+                    try {
+                        return ref.getObjectId().equals(git.getRepository().resolve("HEAD"));
+                    } catch (IOException e) {
+                        return false;
+                    }
+                })
+                .findFirst();
     }
 
     /**

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -226,7 +226,7 @@ public class JGitPropertySource implements PropertySource {
 
                     Optional<Ref> localBranch = localBranch(git, head);
                     localBranch
-                            .map(r -> r.getName().replace("refs/heads/", ""))
+                            .map(r -> Repository.shortenRefName(r.getName()))
                             .ifPresent(branchName -> result.put(JGIT_BRANCH_NAME, branchName));
 
                     if (Boolean.parseBoolean(configuration

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -332,7 +332,7 @@ public class JGitPropertySourceTest {
         Path mainRepo = tempDir.resolve("main-repo");
         Files.createDirectories(mainRepo);
 
-        exec(mainRepo, "git", "init");
+        exec(mainRepo, "git", "init", "-b", "master");
         exec(mainRepo, "git", "config", "user.email", "test@test.com");
         exec(mainRepo, "git", "config", "user.name", "Test");
         Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
@@ -345,7 +345,7 @@ public class JGitPropertySourceTest {
                         .withCurrentWorkingDirectory(mainRepo)
                         .build());
 
-        assertFalse(properties.isEmpty(), "Properties should not be empty when opened from a worktree");
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
         assertEquals("master", properties.get("branchName"));
 
         exec(mainRepo, "git", "branch", "-m", "main");
@@ -355,7 +355,7 @@ public class JGitPropertySourceTest {
                         .withCurrentWorkingDirectory(mainRepo)
                         .build());
 
-        assertFalse(properties.isEmpty(), "Properties should not be empty when opened from a worktree");
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
         assertEquals("main", properties.get("branchName"));
     }
 

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -327,6 +327,38 @@ public class JGitPropertySourceTest {
         assertEquals(mainCommit, mainProperties.get("commit"), "Main repo should still work");
     }
 
+    @Test
+    void testBranchNameDef(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file.txt");
+        exec(mainRepo, "git", "commit", "-m", "initial commit");
+        exec(mainRepo, "git", "tag", "v1.0.0");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty when opened from a worktree");
+        assertEquals("master", properties.get("branchName"));
+
+        exec(mainRepo, "git", "branch", "-m", "main");
+
+        properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty when opened from a worktree");
+        assertEquals("main", properties.get("branchName"));
+    }
+
     private static void exec(Path workDir, String... command) throws Exception {
         Process process = new ProcessBuilder(command)
                 .directory(workDir.toFile())

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -328,7 +328,7 @@ public class JGitPropertySourceTest {
     }
 
     @Test
-    void testBranchNameDef(@TempDir Path tempDir) throws Exception {
+    void testBranchNameSimple(@TempDir Path tempDir) throws Exception {
         Path mainRepo = tempDir.resolve("main-repo");
         Files.createDirectories(mainRepo);
 
@@ -357,6 +357,124 @@ public class JGitPropertySourceTest {
 
         assertFalse(properties.isEmpty(), "Properties should not be empty");
         assertEquals("main", properties.get("branchName"));
+    }
+
+    @Test
+    void testBranchNameDetached(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init", "-b", "master");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file1.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file1.txt");
+        exec(mainRepo, "git", "commit", "-m", "file1");
+        Files.write(mainRepo.resolve("file2.txt"), "hello again".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file2.txt");
+        exec(mainRepo, "git", "commit", "-m", "file2");
+
+        exec(mainRepo, "git", "checkout", "HEAD^");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertFalse(properties.containsKey("branchName"));
+    }
+
+    @Test
+    void testBranchNameWorktree(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init", "-b", "master");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file.txt");
+        exec(mainRepo, "git", "commit", "-m", "initial commit");
+        exec(mainRepo, "git", "tag", "v1.0.0");
+
+        // Create a worktree with an additional commit
+        Path worktree = tempDir.resolve("worktree");
+        exec(mainRepo, "git", "worktree", "add", worktree.toString(), "-b", "master-wt");
+        Files.write(worktree.resolve("worktree-file.txt"), "worktree".getBytes(StandardCharsets.UTF_8));
+        exec(worktree, "git", "add", "worktree-file.txt");
+        exec(worktree, "git", "commit", "-m", "worktree commit");
+
+        String mainCommit = execOutput(mainRepo, "git", "rev-parse", "HEAD").trim();
+        String worktreeCommit = execOutput(worktree, "git", "rev-parse", "HEAD").trim();
+        assertNotEquals(mainCommit, worktreeCommit, "Worktree should have a different HEAD");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(worktree)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertEquals("master-wt", properties.get("branchName"));
+
+        exec(worktree, "git", "branch", "-m", "main-wt");
+
+        properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(worktree)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertEquals("main-wt", properties.get("branchName"));
+
+        // check main repo
+        properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertEquals("master", properties.get("branchName"));
+    }
+
+    @Test
+    void testBranchNameWorktreeDetached(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init", "-b", "master");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file1.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file1.txt");
+        exec(mainRepo, "git", "commit", "-m", "file1 commit");
+        Files.write(mainRepo.resolve("file2.txt"), "hello again".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file2.txt");
+        exec(mainRepo, "git", "commit", "-m", "file2 commit");
+
+        // Create a worktree with an additional commit
+        Path worktree = tempDir.resolve("worktree");
+        exec(mainRepo, "git", "worktree", "add", worktree.toString(), "-b", "master-wt");
+        Files.write(worktree.resolve("worktree-file1.txt"), "worktree".getBytes(StandardCharsets.UTF_8));
+        exec(worktree, "git", "add", "worktree-file1.txt");
+        exec(worktree, "git", "commit", "-m", "worktree-file1 commit");
+        Files.write(worktree.resolve("worktree-file2.txt"), "worktree".getBytes(StandardCharsets.UTF_8));
+        exec(worktree, "git", "add", "worktree-file2.txt");
+        exec(worktree, "git", "commit", "-m", "worktree-file2 commit");
+
+        String mainCommit = execOutput(mainRepo, "git", "rev-parse", "HEAD").trim();
+        String worktreeCommit = execOutput(worktree, "git", "rev-parse", "HEAD").trim();
+        assertNotEquals(mainCommit, worktreeCommit, "Worktree should have a different HEAD");
+
+        exec(worktree, "git", "checkout", "HEAD^");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(worktree)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertFalse(properties.containsKey("branchName"));
     }
 
     private static void exec(Path workDir, String... command) throws Exception {


### PR DESCRIPTION
Adds new JGitPropertySource property: `branchName`, that is added when branch name can be detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `branchName` property that automatically detects and returns the current Git branch name.

* **Tests**
  * Added comprehensive test coverage for branch name detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->