### PR TITLE
Fix #153: Filter version hint tags by reachability from HEAD

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -640,6 +640,7 @@ public class JGitPropertySource implements PropertySource {
 
         Repository repository = git.getRepository();
         return git.tagList().call().stream()
+                .filter(tag -> hintTagPattern.matcher(tag.getName()).matches())
                 .filter(tag -> isReachableFrom(repository, tag, head))
                 .map(Ref::getName)
                 .map(hintTagPattern::matcher)

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -40,6 +40,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -389,7 +390,7 @@ public class JGitPropertySource implements PropertySource {
             boolean isCustomPattern = !DEFAULT_VERSION_HINT_PATTERN.equals(versionHintPattern);
 
             // Then, check for version hint tags
-            Optional<String> versionHint = findVersionHint(configuration, git);
+            Optional<String> versionHint = findVersionHint(configuration, git, head);
             if (versionHint.isPresent()) {
                 VersionInformation hintVersion = new VersionInformation(versionHint.get());
                 logger.debug("Version hint found: {}", hintVersion);
@@ -597,13 +598,14 @@ public class JGitPropertySource implements PropertySource {
      * @return Optional version string extracted from hint tags
      * @throws Exception if git operations fail
      */
-    protected Optional<String> findVersionHint(NisseConfiguration configuration, Git git) throws Exception {
+    protected Optional<String> findVersionHint(NisseConfiguration configuration, Git git, ObjectId head)
+            throws Exception {
         try {
             String hintPattern = configuration
                     .getConfiguration()
                     .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_VERSION_HINT_PATTERN, DEFAULT_VERSION_HINT_PATTERN);
 
-            List<String> hintVersions = findVersionHintTags(git, hintPattern);
+            List<String> hintVersions = findVersionHintTags(git, hintPattern, head);
             logger.debug("Found version hint tags: {}", hintVersions);
 
             return findHighestVersionFromHints(hintVersions);
@@ -620,7 +622,7 @@ public class JGitPropertySource implements PropertySource {
      * @return List of version strings extracted from matching tags
      * @throws GitAPIException if git operations fail
      */
-    protected List<String> findVersionHintTags(Git git, String hintPattern) throws GitAPIException {
+    protected List<String> findVersionHintTags(Git git, String hintPattern, ObjectId head) throws GitAPIException {
         // Convert hint pattern to regex pattern
         // ${version} becomes a capturing group for semantic version
         // We need to be careful about the order of replacements to avoid double-escaping
@@ -636,12 +638,33 @@ public class JGitPropertySource implements PropertySource {
         Pattern hintTagPattern = Pattern.compile("refs/tags/v?" + regexPattern);
         logger.debug("Using version hint regex pattern: {}", hintTagPattern.pattern());
 
+        Repository repository = git.getRepository();
         return git.tagList().call().stream()
+                .filter(tag -> isReachableFrom(repository, tag, head))
                 .map(Ref::getName)
                 .map(hintTagPattern::matcher)
                 .filter(m -> m.matches() && m.groupCount() > 0)
                 .map(m -> m.group(1)) // Extract the version part
                 .collect(Collectors.toList());
+    }
+
+    private boolean isReachableFrom(Repository repository, Ref tag, ObjectId head) {
+        if (head == null) {
+            return true;
+        }
+        try {
+            Ref peeledRef = repository.getRefDatabase().peel(tag);
+            ObjectId tagObjectId =
+                    (peeledRef.getPeeledObjectId() != null ? peeledRef.getPeeledObjectId() : tag.getObjectId());
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit tagCommit = revWalk.parseCommit(tagObjectId);
+                RevCommit headCommit = revWalk.parseCommit(head);
+                return revWalk.isMergedInto(tagCommit, headCommit);
+            }
+        } catch (IOException e) {
+            logger.debug("Could not check reachability for tag {}: {}", tag.getName(), e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -477,6 +477,55 @@ public class JGitPropertySourceTest {
         assertFalse(properties.containsKey("branchName"));
     }
 
+    @Test
+    void testVersionHintReachability(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // Initial commit and release tag
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+        exec(repo, "git", "tag", "1.0.0");
+
+        // Create maintenance branch from this point
+        exec(repo, "git", "branch", "maintenance");
+
+        // Add commit on master with version hint tag (unreachable from maintenance)
+        Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "master work");
+        exec(repo, "git", "tag", "2.0.0-SNAPSHOT");
+
+        // Switch to maintenance, add a commit with release tag
+        exec(repo, "git", "checkout", "maintenance");
+        Files.write(repo.resolve("maint.txt"), "fix".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "maint.txt");
+        exec(repo, "git", "commit", "-m", "maintenance fix");
+        exec(repo, "git", "tag", "1.0.1");
+
+        // Resolve dynamic version from maintenance branch
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> properties = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        String dynamicVersion = properties.get("dynamicVersion");
+        assertNotNull(dynamicVersion, "dynamicVersion should be set");
+        assertEquals(
+                "1.0.1",
+                dynamicVersion,
+                "Should resolve version from maintenance branch tag, not unreachable master hint tag");
+    }
+
     private static void exec(Path workDir, String... command) throws Exception {
         Process process = new ProcessBuilder(command)
                 .directory(workDir.toFile())

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -499,7 +499,7 @@ public class JGitPropertySourceTest {
         Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
         exec(repo, "git", "add", "file.txt");
         exec(repo, "git", "commit", "-m", "master work");
-        exec(repo, "git", "tag", "2.0.0-SNAPSHOT");
+        exec(repo, "git", "tag", "-a", "2.0.0-SNAPSHOT", "-m", "version hint");
 
         // Switch to maintenance, add a commit with release tag
         exec(repo, "git", "checkout", "maintenance");


### PR DESCRIPTION
## Summary

`findVersionHintTags` was listing all tags in the repository via `git.tagList()` without filtering by reachability from HEAD. This caused version hint tags from other branches (e.g., `4.1.0-SNAPSHOT` on `master`) to be picked up when building from a maintenance branch (e.g., `4.0.x`), leading to incorrect version resolution.

**Root cause**: `findVersionHintTags` iterated all tags globally, while `getVersionFromGit` (which resolves release tags) correctly walked only commits reachable from HEAD.

**Fix**: Added a reachability check using JGit's `RevWalk.isMergedInto()` to filter version hint tags to only those whose target commit is an ancestor of HEAD, consistent with `git describe` behavior.

Fixes #153

## Changes

- `JGitPropertySource.findVersionHintTags()` — added `ObjectId head` parameter and reachability filter
- `JGitPropertySource.findVersionHint()` — pass `head` through
- `JGitPropertySource.isReachableFrom()` — new private helper using `RevWalk.isMergedInto()`
- `JGitPropertySourceTest.testVersionHintReachability()` — new test that reproduces the multi-branch scenario

## Test plan

- [x] All 18 existing unit tests pass
- [x] New test creates a multi-branch repo (master with `2.0.0-SNAPSHOT` hint tag, maintenance with `1.0.1` release tag) and verifies dynamic version resolves to `1.0.1` on maintenance branch

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced version hint tag filtering to respect branch reachability and merge state. Version hints from branches not reachable from the target branch are now correctly excluded, preventing incorrect version selection when using dynamic versioning.

* **Tests**
  * Added test coverage for version resolution with unreachable branch hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->