### PR TITLE
Feat: Directive based versioning

### DIFF
--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -23,7 +23,7 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <properties>
-    <version.toolrunner>0.2.1</version.toolrunner>
+    <version.toolrunner>0.2.2</version.toolrunner>
   </properties>
 
   <build>

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -66,6 +66,8 @@ public class JGitPropertySource implements PropertySource {
 
     private static final String JGIT_DYNAMIC_VERSION = "dynamicVersion";
 
+    private static final String JGIT_COUNTING_VERSION = "countingVersion";
+
     private static final String JGIT_CLEAN = "clean";
 
     private static final String JGIT_BRANCH_NAME = "branchName";
@@ -81,11 +83,18 @@ public class JGitPropertySource implements PropertySource {
     /**
      * Set to {@code true} to enable "dynamic version" feature, it adds the
      * {@link #JGIT_DYNAMIC_VERSION} property to resulting properties.
-     *
      */
     private static final String JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION = "nisse.source.jgit.dynamicVersion";
 
     private static final String DEFAULT_DYNAMIC_VERSION = Boolean.FALSE.toString();
+
+    /**
+     * Set to {@code true} to enable "counting version" feature, it adds the
+     * {@link #JGIT_COUNTING_VERSION} property to resulting properties.
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_COUNTING_VERSION = "nisse.source.jgit.countingVersion";
+
+    private static final String DEFAULT_COUNTING_VERSION = Boolean.FALSE.toString();
 
     /**
      * Whether the patch version shall be increased or not, when calculating dynamic version and there is no tag
@@ -235,6 +244,11 @@ public class JGitPropertySource implements PropertySource {
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION, DEFAULT_DYNAMIC_VERSION))) {
                         result.put(JGIT_DYNAMIC_VERSION, resolveDynamicVersion(configuration, git, head));
+                    }
+                    if (Boolean.parseBoolean(configuration
+                            .getConfiguration()
+                            .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_COUNTING_VERSION, DEFAULT_COUNTING_VERSION))) {
+                        result.put(JGIT_COUNTING_VERSION, resolveCountingVersion(configuration, git, head));
                     }
                 }
             }
@@ -440,6 +454,42 @@ public class JGitPropertySource implements PropertySource {
         return vi.toString();
     }
 
+    String resolveCountingVersion(NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
+        VersionInformation vi = getVersionFromGit(configuration, git, head);
+
+        try {
+            RevCommit lastCommit = getLastCommit(git, head);
+            logger.debug("last commit: {}", lastCommit.toString());
+            if (apply(vi, lastCommit.getShortMessage())) {
+                logger.debug("last commit: {} -> {}", lastCommit.getShortMessage(), vi);
+            }
+            logger.debug("counting version resolved to: {}", vi);
+            return mayAddQualifier(configuration, git, vi).toString();
+        } catch (GitAPIException e) {
+            throw new Exception("Error reading Git information.", e);
+        }
+    }
+
+    protected boolean apply(VersionInformation vi, String message) {
+        if (message.contains("[major]")) {
+            vi.incMajor();
+            vi.setMinor(0);
+            vi.setPatch(0);
+            vi.setBuildNumber(0);
+            return true;
+        } else if (message.contains("[minor]")) {
+            vi.incMinor();
+            vi.setPatch(0);
+            vi.setBuildNumber(0);
+            return true;
+        } else if (message.contains("[patch]")) {
+            vi.incPatch();
+            vi.setBuildNumber(0);
+            return true;
+        }
+        return false;
+    }
+
     protected VersionInformation getVersionFromGit(NisseConfiguration configuration, Git git) throws Exception {
         return getVersionFromGit(configuration, git, git.getRepository().resolve("HEAD"));
     }
@@ -490,7 +540,7 @@ public class JGitPropertySource implements PropertySource {
 
     private Optional<VersionInformation> getHighestVersionTagForCommit(
             NisseConfiguration configuration, Git git, RevCommit commit) throws GitAPIException {
-        // get tags use semantic version (X.Y.Z or vX.Y.Z) for for commit
+        // get tags use semantic version (X.Y.Z or vX.Y.Z) for commit
         List<String> versionTagsForCommit = getVersionedTagsForCommit(configuration, git, commit);
         logger.debug("commit {} {}: {}", commit.getId(), commit.getShortMessage(), versionTagsForCommit.toString());
         return findHighestVersion(versionTagsForCommit);

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -460,7 +460,7 @@ public class JGitPropertySource implements PropertySource {
         try {
             RevCommit lastCommit = getLastCommit(git, head);
             logger.debug("last commit: {}", lastCommit.toString());
-            if (apply(vi, lastCommit.getShortMessage())) {
+            if (mayApply(vi, lastCommit.getShortMessage())) {
                 logger.debug("last commit: {} -> {}", lastCommit.getShortMessage(), vi);
             }
             logger.debug("counting version resolved to: {}", vi);
@@ -470,20 +470,25 @@ public class JGitPropertySource implements PropertySource {
         }
     }
 
-    protected boolean apply(VersionInformation vi, String message) {
+    /**
+     * May apply directive in commit message. If applied, returns {@code true} and updates the passed in
+     * {@link VersionInformation} instance.
+     */
+    protected boolean mayApply(VersionInformation vi, String message) {
+        // TODO: config directives
         if (message.contains("[major]")) {
-            vi.incMajor();
+            vi.setMajor(vi.getMajor() + 1);
             vi.setMinor(0);
             vi.setPatch(0);
             vi.setBuildNumber(0);
             return true;
         } else if (message.contains("[minor]")) {
-            vi.incMinor();
+            vi.setMinor(vi.getMinor() + 1);
             vi.setPatch(0);
             vi.setBuildNumber(0);
             return true;
         } else if (message.contains("[patch]")) {
-            vi.incPatch();
+            vi.setPatch(vi.getPatch() + 1);
             vi.setBuildNumber(0);
             return true;
         }

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -459,9 +459,9 @@ public class JGitPropertySource implements PropertySource {
 
         try {
             RevCommit lastCommit = getLastCommit(git, head);
-            logger.debug("last commit: {}", lastCommit.toString());
+            logger.debug("last commit: {}", lastCommit);
             if (mayApply(vi, lastCommit.getShortMessage())) {
-                logger.debug("last commit: {} -> {}", lastCommit.getShortMessage(), vi);
+                logger.debug("last commit is a directive: {} -> {}", lastCommit.getShortMessage(), vi);
             }
             logger.debug("counting version resolved to: {}", vi);
             return mayAddQualifier(configuration, git, vi).toString();

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/VersionInformation.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/VersionInformation.java
@@ -128,20 +128,12 @@ public class VersionInformation {
         this.major = major;
     }
 
-    public int incMajor() {
-        return this.major++;
-    }
-
     public int getMinor() {
         return minor;
     }
 
     public void setMinor(int minor) {
         this.minor = minor;
-    }
-
-    public int incMinor() {
-        return this.minor++;
     }
 
     public int getPatch() {
@@ -152,20 +144,12 @@ public class VersionInformation {
         this.patch = patch;
     }
 
-    public int incPatch() {
-        return this.patch++;
-    }
-
     public long getBuildNumber() {
         return buildNumber;
     }
 
     public void setBuildNumber(long buildNumber) {
         this.buildNumber = buildNumber;
-    }
-
-    public long incBuildNumber() {
-        return this.buildNumber++;
     }
 
     public String getQualifier() {

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/VersionInformation.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/VersionInformation.java
@@ -128,12 +128,20 @@ public class VersionInformation {
         this.major = major;
     }
 
+    public int incMajor() {
+        return this.major++;
+    }
+
     public int getMinor() {
         return minor;
     }
 
     public void setMinor(int minor) {
         this.minor = minor;
+    }
+
+    public int incMinor() {
+        return this.minor++;
     }
 
     public int getPatch() {
@@ -144,12 +152,20 @@ public class VersionInformation {
         this.patch = patch;
     }
 
+    public int incPatch() {
+        return this.patch++;
+    }
+
     public long getBuildNumber() {
         return buildNumber;
     }
 
     public void setBuildNumber(long buildNumber) {
         this.buildNumber = buildNumber;
+    }
+
+    public long incBuildNumber() {
+        return this.buildNumber++;
     }
 
     public String getQualifier() {
@@ -160,6 +176,7 @@ public class VersionInformation {
         this.qualifier = qualifier;
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(this.getMajor());

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -568,9 +568,7 @@ public class JGitPropertySourceTest {
         assertEquals("0.1.1", countingVersion, "Should resolve version");
 
         // v4 release: [minor] - 0.1.1 -> 0.2.0
-        Files.write(repo.resolve("file.txt"), "v4".getBytes(StandardCharsets.UTF_8));
-        exec(repo, "git", "add", "file.txt");
-        exec(repo, "git", "commit", "-m", "[minor] release");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "[minor] release");
 
         properties = source.getProperties(SimpleNisseConfiguration.builder()
                 .withCurrentWorkingDirectory(repo)

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -524,6 +525,69 @@ public class JGitPropertySourceTest {
                 "1.0.1",
                 dynamicVersion,
                 "Should resolve version from maintenance branch tag, not unreachable master hint tag");
+    }
+
+
+    @Test
+    void testCountingVersion(@TempDir Path tempDir) throws Exception {
+        // Resolve counting version
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.countingVersion", "true");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> properties;
+        String countingVersion;
+
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // v1
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+
+        // v2
+        Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "fix");
+
+        // v3 release: [patch] - 0.1.0 -> 0.1.1
+        Files.write(repo.resolve("file.txt"), "v3".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "[patch] release");
+
+        properties = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        countingVersion = properties.get("countingVersion");
+        assertNotNull(countingVersion, "countingVersion should be set");
+        assertEquals(
+                "0.1.1",
+                countingVersion,
+                "Should resolve version");
+
+        // v4 release: [minor] - 0.1.1 -> 0.2.0
+        Files.write(repo.resolve("file.txt"), "v4".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "[minor] release");
+
+        properties = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        countingVersion = properties.get("countingVersion");
+        assertNotNull(countingVersion, "countingVersion should be set");
+        assertEquals(
+                "0.2.0",
+                countingVersion,
+                "Should resolve version");
     }
 
     private static void exec(Path workDir, String... command) throws Exception {

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -532,6 +532,7 @@ public class JGitPropertySourceTest {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.countingVersion", "true");
         userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        userProps.put("nisse.source.jgit.increasePatchVersion", "false");
         JGitPropertySource source = new JGitPropertySource();
         Map<String, String> properties;
         String countingVersion;
@@ -543,41 +544,100 @@ public class JGitPropertySourceTest {
         exec(repo, "git", "config", "user.email", "test@test.com");
         exec(repo, "git", "config", "user.name", "Test");
 
+        // HEAD must exist
+
         // v1
         Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
         exec(repo, "git", "add", "file.txt");
         exec(repo, "git", "commit", "-m", "initial");
+
+        // starting semver is 0.1.0 and +1 commit
+        assertProperty(
+                "countingVersion",
+                "0.1.0-1",
+                source.getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(repo)
+                        .withUserProperties(userProps)
+                        .build()));
 
         // v2
         Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
         exec(repo, "git", "add", "file.txt");
         exec(repo, "git", "commit", "-m", "fix");
 
+        // starting semver is 0.1.0 and +2 commit
+        assertProperty(
+                "countingVersion",
+                "0.1.0-2",
+                source.getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(repo)
+                        .withUserProperties(userProps)
+                        .build()));
+
         // v3 release: [patch] - 0.1.0 -> 0.1.1
         Files.write(repo.resolve("file.txt"), "v3".getBytes(StandardCharsets.UTF_8));
         exec(repo, "git", "add", "file.txt");
         exec(repo, "git", "commit", "-m", "[patch] release");
 
-        properties = source.getProperties(SimpleNisseConfiguration.builder()
-                .withCurrentWorkingDirectory(repo)
-                .withUserProperties(userProps)
-                .build());
+        // release 0.1.1
+        assertProperty(
+                "countingVersion",
+                "0.1.1",
+                source.getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(repo)
+                        .withUserProperties(userProps)
+                        .build()));
 
-        countingVersion = properties.get("countingVersion");
-        assertNotNull(countingVersion, "countingVersion should be set");
-        assertEquals("0.1.1", countingVersion, "Should resolve version");
+        // tag release
+        exec(repo, "git", "tag", "0.1.1");
 
-        // v4 release: [minor] - 0.1.1 -> 0.2.0
+        // v4
+        Files.write(repo.resolve("file.txt"), "v4".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "fix");
+
+        // 0.1.1 and +1 commit
+        assertProperty(
+                "countingVersion",
+                "0.1.1-1",
+                source.getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(repo)
+                        .withUserProperties(userProps)
+                        .build()));
+
+        // v5 release: [minor] - 0.1.1 -> 0.2.0
         exec(repo, "git", "commit", "--allow-empty", "-m", "[minor] release");
 
-        properties = source.getProperties(SimpleNisseConfiguration.builder()
-                .withCurrentWorkingDirectory(repo)
-                .withUserProperties(userProps)
-                .build());
+        assertProperty(
+                "countingVersion",
+                "0.2.0",
+                source.getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(repo)
+                        .withUserProperties(userProps)
+                        .build()));
 
-        countingVersion = properties.get("countingVersion");
-        assertNotNull(countingVersion, "countingVersion should be set");
-        assertEquals("0.2.0", countingVersion, "Should resolve version");
+        // tag release
+        exec(repo, "git", "tag", "0.2.0");
+
+        // v6
+        Files.write(repo.resolve("file.txt"), "v6".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "fix");
+
+        // 0.2.0 and +1 commit
+        assertProperty(
+                "countingVersion",
+                "0.2.0-1",
+                source.getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(repo)
+                        .withUserProperties(userProps)
+                        .build()));
+    }
+
+    private static void assertProperty(String key, String expectedValue, Map<String, String> properties) {
+        String value = properties.get("countingVersion");
+        assertNotNull(value, key + " should be set");
+        assertEquals(expectedValue, value, "Unexpected value for countingVersion: " + key);
     }
 
     private static void exec(Path workDir, String... command) throws Exception {

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -527,7 +526,6 @@ public class JGitPropertySourceTest {
                 "Should resolve version from maintenance branch tag, not unreachable master hint tag");
     }
 
-
     @Test
     void testCountingVersion(@TempDir Path tempDir) throws Exception {
         // Resolve counting version
@@ -567,10 +565,7 @@ public class JGitPropertySourceTest {
 
         countingVersion = properties.get("countingVersion");
         assertNotNull(countingVersion, "countingVersion should be set");
-        assertEquals(
-                "0.1.1",
-                countingVersion,
-                "Should resolve version");
+        assertEquals("0.1.1", countingVersion, "Should resolve version");
 
         // v4 release: [minor] - 0.1.1 -> 0.2.0
         Files.write(repo.resolve("file.txt"), "v4".getBytes(StandardCharsets.UTF_8));
@@ -584,10 +579,7 @@ public class JGitPropertySourceTest {
 
         countingVersion = properties.get("countingVersion");
         assertNotNull(countingVersion, "countingVersion should be set");
-        assertEquals(
-                "0.2.0",
-                countingVersion,
-                "Should resolve version");
+        assertEquals("0.2.0", countingVersion, "Should resolve version");
     }
 
     private static void exec(Path workDir, String... command) throws Exception {


### PR DESCRIPTION
New versioning scheme, that listens to "directives" in commits, and if found, applies them and return set version.

Logic:
* version starts with `0.1.0` initial semver (as defined by semver)
* each "plain" commit increased build number (so `0.1.0-1`, `0.1.0-2`...)
* each "directive" applies major/minor/patch directive increases given segment (and nullifies all values right hand of it) -- for example `0.1.0-5` -minor-> `0.2.0`.
* Nisse **does not tag**, so this logic is half assed without tagging (and maybe even pushing?)

TODO: configuration for directives.