### PR TITLE
Gradle plugin: add nisseConfig DSL, tests, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ Note that this only works when Nisse is declared as a ["core extension"](https:/
 (Maven 3 and 4) through **.mvn/extensions.xml** or as a "user-wide extension" (Maven 4 only) through **~/.m2/extensions.xml**.
 Otherwise, one may use `dump-properties` Mojo or the `nisse.dump` property of `inject-properties` Mojo. 
 
+## Usage with Gradle
+
+Nisse is also available as a Gradle plugin. See the [Gradle Plugin documentation](gradle/README.md) for full details.
+
+Minimal setup:
+
+```groovy
+plugins {
+    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin") version "${nisseVersion}"
+}
+
+// Access discovered properties in tasks
+tasks.register("showVersion") {
+    doLast {
+        println "OS: ${project.nisse['nisse.os.name']}"
+        println "Git commit: ${project.nisse['nisse.jgit.commit']}"
+    }
+}
+```
+
+The plugin supports a `nisseConfig` DSL for configuring sources (dynamic version, counting
+version, deactivating sources, etc.) — see the [Gradle README](gradle/README.md).
+
 ## Implemented Sources
 
 There are 4 sources provided out of the box:

--- a/gradle/.gitignore
+++ b/gradle/.gitignore
@@ -1,6 +1,6 @@
-.gradle/
-build/
-gradle/
+/.gradle/
+/build/
+/gradle/
 gradlew
 gradlew.bat
 *.class

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -1,0 +1,269 @@
+# Nisse Gradle Plugin
+
+The Nisse Gradle plugin provides the same property-source functionality as the
+[Maven extension](../README.md) but for Gradle builds. It discovers properties from
+multiple sources (Git via JGit, OS detection) and makes them available to your build.
+
+## Requirements
+
+* Java 8+
+* Gradle 8.x+
+
+## Quick Start — Minimal Setup
+
+Apply the plugin. All sources (jgit, os) are active by default:
+
+```groovy
+plugins {
+    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin") version "${nisseVersion}"
+}
+
+tasks.register("showVersion") {
+    doLast {
+        println "OS:   ${project.nisse['nisse.os.name']}"
+        println "Arch: ${project.nisse['nisse.os.arch']}"
+        println "Git commit: ${project.nisse['nisse.jgit.commit']}"
+    }
+}
+```
+
+That's it — no further configuration required.
+
+> **Note:** The `nisse` extension (a `Map<String, String>`) is populated during project
+> evaluation, so access it inside `doLast { }` blocks, `afterEvaluate { }`, or other
+> deferred contexts rather than at the top level of your build script.
+
+## The `nisse` Extension
+
+The plugin registers a `nisse` extension on the project. It is a `Map<String, String>`
+containing all properties discovered by the active sources.
+
+### Available Properties
+
+#### OS Source (`nisse.os.*`)
+
+| Property | Description |
+|---|---|
+| `nisse.os.name` | Detected OS name (`osx`, `linux`, `windows`, …) |
+| `nisse.os.arch` | Detected architecture (`x86_64`, `aarch_64`, …) |
+| `nisse.os.bitness` | Bit width (`32` or `64`) |
+| `nisse.os.version` | OS kernel version (e.g. `14.5`) |
+| `nisse.os.version.major` | Major part of the OS version |
+| `nisse.os.version.minor` | Minor part of the OS version |
+| `nisse.os.classifier` | Composite classifier (e.g. `osx-aarch_64`) |
+| `nisse.os.release` | Linux distribution ID (Linux only) |
+| `nisse.os.release.version` | Linux distribution version (Linux only) |
+| `nisse.os.release.like.*` | Linux distribution compatibility (Linux only) |
+
+#### JGit Source (`nisse.jgit.*`)
+
+Always present when the project is inside a Git repository:
+
+| Property | Description |
+|---|---|
+| `nisse.jgit.commit` | Full commit hash of HEAD |
+| `nisse.jgit.shortCommitId` | Abbreviated commit hash (default 7 chars) |
+| `nisse.jgit.date` | Commit timestamp |
+| `nisse.jgit.author` | Author of HEAD commit |
+| `nisse.jgit.committer` | Committer of HEAD commit |
+| `nisse.jgit.clean` | `true` if the working tree is clean |
+| `nisse.jgit.branchName` | Current branch name (if on a branch) |
+
+Conditional properties (require explicit opt-in via `nisseConfig`):
+
+| Property | Description |
+|---|---|
+| `nisse.jgit.dynamicVersion` | Version derived from Git tags (requires `dynamicVersion = true`) |
+| `nisse.jgit.countingVersion` | Version derived from commit message directives (requires `countingVersion = true`) |
+
+## Configuration via `nisseConfig` DSL
+
+Use the `nisseConfig` block to configure property sources:
+
+```groovy
+plugins {
+    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin") version "${nisseVersion}"
+}
+
+nisseConfig {
+    jgit {
+        dynamicVersion = true
+        appendSnapshot = false
+    }
+}
+```
+
+### Deactivating a Source
+
+```groovy
+nisseConfig {
+    jgit {
+        active = false   // disable Git-based properties entirely
+    }
+    os {
+        active = false   // disable OS detection properties
+    }
+}
+```
+
+### JGit Source Options
+
+All options correspond to `nisse.source.jgit.*` system properties. When set via the DSL,
+they take precedence over system properties.
+
+```groovy
+nisseConfig {
+    jgit {
+        // --- source activation ---
+        active = true                        // default: true
+
+        // --- general ---
+        shortCommitIdLength = 10             // default: 7
+        dateFormat = 'iso8601'               // 'git' (default), 'iso8601', 'iso8601-offset', 'custom'
+        dateFormatPattern = 'yyyyMMdd'       // only used when dateFormat = 'custom'
+
+        // --- dynamic version (tag-based) ---
+        dynamicVersion = true                // default: false
+        increasePatchVersion = true          // default: true
+        appendBuildNumber = true             // default: true
+        appendSnapshot = true                // default: true
+        appendDirty = false                  // default: false
+        dirtyQualifier = 'DIRTY'             // default: 'DIRTY'
+        useVersion = '1.2.3'                 // override: bypass Git detection entirely
+        versionHintPattern = '${version}-SNAPSHOT'  // default: '${version}-SNAPSHOT'
+
+        // --- counting version (commit-message-based) ---
+        countingVersion = true               // default: false
+        countingStartMajor = 0               // default: 0
+        countingStartMinor = 0               // default: 0
+        countingStartPatch = 0               // default: 0
+        countingMatchMajor = '[major]'       // default: '[major]'
+        countingMatchMinor = '[minor]'       // default: '[minor]'
+        countingMatchPatch = '[patch]'       // default: '[patch]'
+        countingPattern = '%M.%m.%p(-%c)'    // default: '%M.%m.%p(-%c)'
+    }
+}
+```
+
+### OS Source Options
+
+```groovy
+nisseConfig {
+    os {
+        active = true   // default: true
+    }
+}
+```
+
+## Dynamic Version
+
+When `dynamicVersion = true`, the jgit source derives a version from the most recent
+semver Git tag (e.g. `v1.2.3` or `1.2.3`). If HEAD is not on a tag, the patch version
+is incremented, a build number is appended, and optionally a `-SNAPSHOT` qualifier:
+
+```text
+v1.2.3  →  on tag: 1.2.3
+         not on tag: 1.2.4-5-SNAPSHOT  (5 commits after tag)
+```
+
+Control the output with `appendSnapshot`, `appendBuildNumber`, `increasePatchVersion`,
+`appendDirty`, and `dirtyQualifier`.
+
+## Counting Version
+
+When `countingVersion = true`, the jgit source walks the **entire** commit history
+from oldest to newest and derives a version from commit message directives:
+
+* A commit containing `[major]` → bumps major, resets minor/patch/count
+* A commit containing `[minor]` → bumps minor, resets patch/count
+* A commit containing `[patch]` → bumps patch, resets count
+* Any other commit → increments the commit count
+
+The default output pattern `%M.%m.%p(-%c)` produces versions like:
+
+```text
+0.0.0       (no commits)
+0.0.0-3     (3 ordinary commits)
+1.0.0       ([major] commit, no further commits)
+1.1.0-2     ([major], then [minor], then 2 ordinary commits)
+```
+
+The pattern is configurable — for example, `%M.%m.%p(.%c)` uses dots instead of
+dashes (compatible with [gradle-git-versioner](https://github.com/nickolay-kondratyev/gradle-git-versioner)).
+
+### Example: Using Counting Version as Project Version
+
+```groovy
+plugins {
+    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin") version "${nisseVersion}"
+}
+
+nisseConfig {
+    jgit {
+        countingVersion = true
+    }
+}
+
+// nisse properties are available after evaluation
+afterEvaluate {
+    version = project.nisse['nisse.jgit.countingVersion'] ?: '0.0.0'
+}
+```
+
+With a history like:
+```text
+commit 3: "bugfix"                → commitCount=1
+commit 2: "[minor] add feature"   → minor=1, reset count
+commit 1: "[major] initial"       → major=1, reset minor/patch/count
+```
+
+`project.version` resolves to `1.1.0-1`.
+
+### Example: Counting Version with Custom Start and Pattern
+
+```groovy
+nisseConfig {
+    jgit {
+        countingVersion = true
+        countingStartMajor = 2
+        countingPattern = '%M.%m.%p(.%c)'   // dot-separated commit count
+    }
+}
+```
+
+## Dumping Properties
+
+Use the built-in `nisseDump` task to inspect all discovered properties:
+
+```text
+> gradle nisseDump
+
+> Task :nisseDump
+Nisse dump:
+nisse.os.name=osx
+nisse.os.arch=aarch_64
+nisse.os.bitness=64
+nisse.os.classifier=osx-aarch_64
+nisse.jgit.commit=abc1234...
+nisse.jgit.shortCommitId=abc1234
+nisse.jgit.clean=true
+nisse.jgit.branchName=main
+...
+```
+
+## System Property Fallback
+
+All configuration options can also be set via system properties (e.g., on the command
+line or in `gradle.properties`). The DSL takes precedence when both are set.
+
+```properties
+# gradle.properties
+systemProp.nisse.source.jgit.dynamicVersion=true
+systemProp.nisse.source.jgit.appendSnapshot=false
+```
+
+Or on the command line:
+
+```shell
+gradle build -Dnisse.source.jgit.dynamicVersion=true
+```

--- a/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseExtension.java
+++ b/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseExtension.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.gradle.nisse.plugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+/**
+ * Gradle DSL extension for configuring Nisse.
+ *
+ * <pre>
+ * nisseConfig {
+ *     jgit {
+ *         active = true
+ *         dynamicVersion = true
+ *         appendSnapshot = false
+ *     }
+ *     os {
+ *         active = true
+ *     }
+ * }
+ * </pre>
+ */
+public abstract class NisseExtension {
+
+    private final JGitExtension jgit;
+    private final OsExtension os;
+
+    @Inject
+    public NisseExtension(ObjectFactory objects) {
+        this.jgit = objects.newInstance(JGitExtension.class);
+        this.os = objects.newInstance(OsExtension.class);
+    }
+
+    /**
+     * Returns the JGit source configuration.
+     */
+    public JGitExtension getJgit() {
+        return jgit;
+    }
+
+    /**
+     * Configures the JGit source.
+     *
+     * @param action the configuration action
+     */
+    public void jgit(Action<? super JGitExtension> action) {
+        action.execute(jgit);
+    }
+
+    /**
+     * Returns the OS source configuration.
+     */
+    public OsExtension getOs() {
+        return os;
+    }
+
+    /**
+     * Configures the OS source.
+     *
+     * @param action the configuration action
+     */
+    public void os(Action<? super OsExtension> action) {
+        action.execute(os);
+    }
+
+    /**
+     * Converts the DSL configuration into a flat map of Nisse configuration properties
+     * (e.g. {@code nisse.source.jgit.dynamicVersion=true}).
+     */
+    Map<String, String> toUserProperties() {
+        Map<String, String> props = new HashMap<>();
+        jgit.contribute(props);
+        os.contribute(props);
+        return props;
+    }
+
+    /**
+     * JGit source configuration.
+     */
+    public abstract static class JGitExtension {
+        /** Whether the jgit source is active. Defaults to {@code true}. */
+        public abstract Property<Boolean> getActive();
+
+        /** Enable dynamic version computation from git tags. */
+        public abstract Property<Boolean> getDynamicVersion();
+
+        /** Enable counting version computation from git tags. */
+        public abstract Property<Boolean> getCountingVersion();
+
+        /** Length of the short commit id. */
+        public abstract Property<Integer> getShortCommitIdLength();
+
+        /** Whether to increase the patch version. */
+        public abstract Property<Boolean> getIncreasePatchVersion();
+
+        /** Whether to append the build number. */
+        public abstract Property<Boolean> getAppendBuildNumber();
+
+        /** Whether to append {@code -SNAPSHOT} qualifier. */
+        public abstract Property<Boolean> getAppendSnapshot();
+
+        /** Whether to append a dirty qualifier when the working tree is dirty. */
+        public abstract Property<Boolean> getAppendDirty();
+
+        /** The qualifier string to use when the working tree is dirty. */
+        public abstract Property<String> getDirtyQualifier();
+
+        /** Override the version to use (bypass git-based detection). */
+        public abstract Property<String> getUseVersion();
+
+        /** Pattern for extracting version hints from tag names. */
+        public abstract Property<String> getVersionHintPattern();
+
+        /** Date format to use ({@code git}, {@code iso}, {@code custom}). */
+        public abstract Property<String> getDateFormat();
+
+        /** Custom date format pattern (when dateFormat is {@code custom}). */
+        public abstract Property<String> getDateFormatPattern();
+
+        /** Counting version start major. */
+        public abstract Property<Integer> getCountingStartMajor();
+
+        /** Counting version start minor. */
+        public abstract Property<Integer> getCountingStartMinor();
+
+        /** Counting version start patch. */
+        public abstract Property<Integer> getCountingStartPatch();
+
+        /** Counting version match major pattern. */
+        public abstract Property<String> getCountingMatchMajor();
+
+        /** Counting version match minor pattern. */
+        public abstract Property<String> getCountingMatchMinor();
+
+        /** Counting version match patch pattern. */
+        public abstract Property<String> getCountingMatchPatch();
+
+        /** Counting version output pattern. */
+        public abstract Property<String> getCountingPattern();
+
+        void contribute(Map<String, String> props) {
+            setIfPresent(props, "nisse.source.jgit.active", getActive());
+            setIfPresent(props, "nisse.source.jgit.dynamicVersion", getDynamicVersion());
+            setIfPresent(props, "nisse.source.jgit.countingVersion", getCountingVersion());
+            setIfPresent(props, "nisse.source.jgit.shortCommitIdLength", getShortCommitIdLength());
+            setIfPresent(props, "nisse.source.jgit.increasePatchVersion", getIncreasePatchVersion());
+            setIfPresent(props, "nisse.source.jgit.appendBuildNumber", getAppendBuildNumber());
+            setIfPresent(props, "nisse.source.jgit.appendSnapshot", getAppendSnapshot());
+            setIfPresent(props, "nisse.source.jgit.appendDirty", getAppendDirty());
+            setIfPresent(props, "nisse.source.jgit.dirtyQualifier", getDirtyQualifier());
+            setIfPresent(props, "nisse.source.jgit.useVersion", getUseVersion());
+            setIfPresent(props, "nisse.source.jgit.versionHintPattern", getVersionHintPattern());
+            setIfPresent(props, "nisse.source.jgit.dateFormat", getDateFormat());
+            setIfPresent(props, "nisse.source.jgit.dateFormat.pattern", getDateFormatPattern());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.startMajor", getCountingStartMajor());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.startMinor", getCountingStartMinor());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.startPatch", getCountingStartPatch());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.matchMajor", getCountingMatchMajor());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.matchMinor", getCountingMatchMinor());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.matchPatch", getCountingMatchPatch());
+            setIfPresent(props, "nisse.source.jgit.countingVersion.pattern", getCountingPattern());
+        }
+    }
+
+    /**
+     * OS detector source configuration.
+     */
+    public abstract static class OsExtension {
+        /** Whether the os source is active. Defaults to {@code true}. */
+        public abstract Property<Boolean> getActive();
+
+        void contribute(Map<String, String> props) {
+            setIfPresent(props, "nisse.source.os.active", getActive());
+        }
+    }
+
+    private static void setIfPresent(Map<String, String> props, String key, Property<?> property) {
+        if (property.isPresent()) {
+            props.put(key, property.get().toString());
+        }
+    }
+}

--- a/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NissePlugin.java
+++ b/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NissePlugin.java
@@ -13,22 +13,39 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 
 /**
- * Nisse plugin that crates value source with Nisse properties.
+ * Nisse plugin that creates value source with Nisse properties.
+ * <p>
+ * Registers two extensions:
+ * <ul>
+ *   <li>{@code nisseConfig} — DSL for configuring property sources (jgit, os)</li>
+ *   <li>{@code nisse} — resolved {@code Map<String, String>} of discovered properties
+ *       (available after project evaluation)</li>
+ * </ul>
  */
 public class NissePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project target) {
-        Provider<Map<String, String>> provider = target.getProviders().of(NisseValueSource.class, p -> {
-            p.getParameters().getCwd().set(target.getProjectDir());
-            p.getParameters().getRoot().set(target.getRootDir());
-        });
+        NisseExtension extension = target.getExtensions().create("nisseConfig", NisseExtension.class);
 
-        target.getExtensions().add("nisse", provider.get());
+        // Defer creation of the nisse properties map until after the build script has been
+        // evaluated, so that the nisseConfig { ... } DSL block has been processed.
+        target.afterEvaluate(project -> {
+            Provider<Map<String, String>> provider = project.getProviders().of(NisseValueSource.class, p -> {
+                p.getParameters().getCwd().set(project.getProjectDir());
+                p.getParameters().getRoot().set(project.getRootDir());
+                p.getParameters().getUserProperties().set(extension.toUserProperties());
+            });
 
-        target.getTasks().register("nisseDump", p -> {
-            System.out.println("Nisse dump:");
-            provider.get().forEach((key, value) -> System.out.println(key + "=" + value));
+            Map<String, String> properties = provider.get();
+            project.getExtensions().add("nisse", properties);
+
+            project.getTasks().register("nisseDump", t -> {
+                t.doLast(a -> {
+                    System.out.println("Nisse dump:");
+                    properties.forEach((key, value) -> System.out.println(key + "=" + value));
+                });
+            });
         });
     }
 }

--- a/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseValueSource.java
+++ b/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseValueSource.java
@@ -13,6 +13,7 @@ import eu.maveniverse.maven.nisse.core.simple.SimpleNisseManager;
 import eu.maveniverse.maven.nisse.source.jgit.JGitPropertySource;
 import eu.maveniverse.maven.nisse.source.osdetector.OsDetectorPropertySource;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import org.gradle.api.provider.ValueSource;
 import org.jspecify.annotations.Nullable;
@@ -23,8 +24,12 @@ import org.jspecify.annotations.Nullable;
 public abstract class NisseValueSource implements ValueSource<Map<String, String>, NisseValueSourceParam> {
     @Override
     public @Nullable Map<String, String> obtain() {
+        Map<String, String> userProperties = getParameters().getUserProperties().isPresent()
+                ? getParameters().getUserProperties().get()
+                : Collections.emptyMap();
         NisseConfiguration configuration = SimpleNisseConfiguration.builder()
                 .withSystemProperties(System.getProperties())
+                .withUserProperties(userProperties)
                 .withCurrentWorkingDirectory(getParameters().getCwd().get().toPath())
                 .withSessionRootDirectory(getParameters().getRoot().get().toPath())
                 .build();

--- a/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseValueSourceParam.java
+++ b/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseValueSourceParam.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.gradle.nisse.plugin;
 
 import java.io.File;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ValueSourceParameters;
 
@@ -28,4 +29,13 @@ public interface NisseValueSourceParam extends ValueSourceParameters {
      * @return the path of root directory.
      */
     Property<File> getRoot();
+
+    /**
+     * User-provided configuration properties from the {@code nisseConfig} DSL extension.
+     * These are passed as user properties to the Nisse configuration
+     * (e.g. {@code nisse.source.jgit.dynamicVersion=true}).
+     *
+     * @return the map of user properties.
+     */
+    MapProperty<String, String> getUserProperties();
 }

--- a/gradle/src/test/java/eu/maveniverse/gradle/nisse/plugin/NissePluginTest.java
+++ b/gradle/src/test/java/eu/maveniverse/gradle/nisse/plugin/NissePluginTest.java
@@ -7,11 +7,13 @@
  */
 package eu.maveniverse.gradle.nisse.plugin;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
@@ -41,9 +43,13 @@ public class NissePluginTest {
                 plugins {
                     id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
                 }
-                print 'Nisse was here: ' + project.properties.nisse['nisse.os.name']
+                tasks.register("showOsName") {
+                    doLast {
+                        print 'Nisse was here: ' + project.nisse['nisse.os.name']
+                    }
+                }
                 """);
-        BuildResult result = runner().run();
+        BuildResult result = runner().withArguments("showOsName").run();
         String output = result.getOutput();
         int idx = output.indexOf("Nisse was here: ");
         assertTrue(idx >= 0, "Expected 'Nisse was here: ' in output: " + output);
@@ -52,6 +58,217 @@ public class NissePluginTest {
                 .findFirst()
                 .orElse("");
         assertTrue(!value.isEmpty() && !value.equals("null"), "Expected non-empty os.name but got: '" + value + "'");
+    }
+
+    /**
+     * Minimal setup example: just apply the plugin and all sources (jgit, os-detector) are active by default.
+     * The nisse extension is available as a Map of discovered properties.
+     */
+    @Test
+    void minimalSetup() throws IOException {
+        writeFile("settings.gradle", "rootProject.name = \"test\"");
+        writeFile("build.gradle", """
+                plugins {
+                    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
+                }
+                // Access nisse properties via the 'nisse' extension (a Map<String, String>)
+                tasks.register("showVersion") {
+                    doLast {
+                        println "OS: ${project.nisse['nisse.os.name']}"
+                        println "Arch: ${project.nisse['nisse.os.arch']}"
+                    }
+                }
+                """);
+        BuildResult result = runner().withArguments("showVersion").run();
+        String output = result.getOutput();
+        assertTrue(output.contains("OS: "), "Expected OS property in output: " + output);
+        assertTrue(output.contains("Arch: "), "Expected Arch property in output: " + output);
+    }
+
+    /**
+     * Configuration example: deactivate the jgit source via the nisseConfig DSL and verify
+     * that jgit properties are absent while os-detector properties remain available.
+     */
+    @Test
+    void configureDeactivateSource() throws IOException {
+        writeFile("settings.gradle", "rootProject.name = \"test\"");
+        writeFile("build.gradle", """
+                plugins {
+                    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
+                }
+                // Use the nisseConfig DSL to deactivate the jgit source
+                nisseConfig {
+                    jgit {
+                        active = false
+                    }
+                }
+                tasks.register("checkProperties") {
+                    doLast {
+                        def props = project.nisse
+                        // os-detector properties should still be present
+                        println "os.name=" + props['nisse.os.name']
+                        // jgit properties should be absent since jgit source was deactivated
+                        println "jgit.commit=" + props.getOrDefault('nisse.jgit.commit', 'ABSENT')
+                    }
+                }
+                """);
+        BuildResult result = runner().withArguments("checkProperties").run();
+        String output = result.getOutput();
+        // os-detector properties should be present
+        assertTrue(output.contains("os.name="), "Expected os.name in output: " + output);
+        assertFalse(output.contains("os.name=null"), "os.name should not be null: " + output);
+        // jgit properties should be absent
+        assertTrue(output.contains("jgit.commit=ABSENT"), "Expected jgit.commit to be ABSENT: " + output);
+    }
+
+    /**
+     * Configuration example: configure jgit source options via the nisseConfig DSL.
+     */
+    @Test
+    void configureJgitViaDsl() throws IOException {
+        writeFile("settings.gradle", "rootProject.name = \"test\"");
+        writeFile("build.gradle", """
+                plugins {
+                    id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
+                }
+                // Configure jgit source via nisseConfig DSL
+                nisseConfig {
+                    jgit {
+                        dynamicVersion = true
+                        appendSnapshot = false
+                        appendDirty = true
+                        dirtyQualifier = 'WIP'
+                        shortCommitIdLength = 10
+                    }
+                }
+                tasks.register("showNisse") {
+                    doLast {
+                        def props = project.nisse
+                        println "os.name=" + props['nisse.os.name']
+                        // jgit properties should be present (source is active)
+                        props.findAll { it.key.startsWith('nisse.jgit.') }.each {
+                            println it.key + '=' + it.value
+                        }
+                    }
+                }
+                """);
+        BuildResult result = runner().withArguments("showNisse").run();
+        String output = result.getOutput();
+        assertTrue(output.contains("os.name="), "Expected os.name in output: " + output);
+    }
+
+    /**
+     * Configuration example: enable counting version via the nisseConfig DSL.
+     * Counting version walks the commit history and derives a version from commit message
+     * directives ([major], [minor], [patch]). Commits without a directive increment the
+     * commit count.
+     */
+    @Test
+    void configureCountingVersion() throws Exception {
+        // Set up a git repo with commits that exercise counting version directives
+        try (Git git = Git.init().setDirectory(projectDir.toFile()).call()) {
+            writeFile("settings.gradle", "rootProject.name = \"test\"");
+            writeFile("build.gradle", """
+                    plugins {
+                        id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
+                    }
+                    nisseConfig {
+                        jgit {
+                            countingVersion = true
+                        }
+                    }
+                    tasks.register("printCountingVersion") {
+                        doLast {
+                            println "countingVersion=" + project.nisse['nisse.jgit.countingVersion']
+                        }
+                    }
+                    """);
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage("initial commit").call(); // commitCount=1 -> 0.0.0-1
+            git.commit().setAllowEmpty(true).setMessage("[major] first major").call(); // major=1, reset
+            git.commit().setAllowEmpty(true).setMessage("some work").call(); // commitCount=1
+            git.commit().setAllowEmpty(true).setMessage("[minor] add feature").call(); // minor=1, reset
+            git.commit().setAllowEmpty(true).setMessage("fix typo").call(); // commitCount=1
+            git.commit().setAllowEmpty(true).setMessage("another fix").call(); // commitCount=2 -> 1.1.0-2
+        }
+
+        BuildResult result = runner().withArguments("printCountingVersion").run();
+        String output = result.getOutput();
+        assertTrue(output.contains("countingVersion=1.1.0-2"), "Expected counting version 1.1.0-2 but got: " + output);
+    }
+
+    /**
+     * Configuration example: counting version with a custom pattern and start values.
+     */
+    @Test
+    void configureCountingVersionCustomPattern() throws Exception {
+        try (Git git = Git.init().setDirectory(projectDir.toFile()).call()) {
+            writeFile("settings.gradle", "rootProject.name = \"test\"");
+            writeFile("build.gradle", """
+                    plugins {
+                        id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
+                    }
+                    nisseConfig {
+                        jgit {
+                            countingVersion = true
+                            countingStartMajor = 2
+                            countingStartMinor = 0
+                            countingStartPatch = 0
+                            countingPattern = '%M.%m.%p(.%c)'
+                        }
+                    }
+                    tasks.register("printCountingVersion") {
+                        doLast {
+                            println "countingVersion=" + project.nisse['nisse.jgit.countingVersion']
+                        }
+                    }
+                    """);
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage("initial").call(); // commitCount=1
+            git.commit().setAllowEmpty(true).setMessage("[minor] feature").call(); // minor=1, reset
+            git.commit().setAllowEmpty(true).setMessage("tweak").call(); // commitCount=1 -> 2.1.0.1
+        }
+
+        BuildResult result = runner().withArguments("printCountingVersion").run();
+        String output = result.getOutput();
+        assertTrue(output.contains("countingVersion=2.1.0.1"), "Expected counting version 2.1.0.1 but got: " + output);
+    }
+
+    /**
+     * Configuration example: use counting version from Git history as the project version.
+     * This is the recommended way to derive a project version from Git with Nisse.
+     */
+    @Test
+    void configureUseInProjectVersion() throws Exception {
+        try (Git git = Git.init().setDirectory(projectDir.toFile()).call()) {
+            writeFile("settings.gradle", "rootProject.name = \"test\"");
+            writeFile("build.gradle", """
+                    plugins {
+                        id("eu.maveniverse.gradle.plugins.nisse-gradle-plugin")
+                    }
+                    nisseConfig {
+                        jgit {
+                            countingVersion = true
+                        }
+                    }
+                    afterEvaluate {
+                        version = project.nisse['nisse.jgit.countingVersion']
+                    }
+                    tasks.register("showProjectVersion") {
+                        doLast {
+                            println "project.version=" + project.version
+                        }
+                    }
+                    """);
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage("[major] initial release").call(); // major=1
+            git.commit().setAllowEmpty(true).setMessage("[minor] add feature").call(); // minor=1
+            git.commit().setAllowEmpty(true).setMessage("bugfix").call(); // commitCount=1 -> 1.1.0-1
+        }
+
+        BuildResult result = runner().withArguments("showProjectVersion").run();
+        String output = result.getOutput();
+        assertTrue(output.contains("project.version=1.1.0-1"), "Expected project.version=1.1.0-1 but got: " + output);
     }
 
     private GradleRunner runner() {


### PR DESCRIPTION
Currently configuration is done via global system properties which isn't as gradle nice - so went and added support for userProperties using gradle dsl + add some more docs so its a bit more obvious what/how nisse does :)

## Summary

Adds idiomatic Gradle DSL configuration, comprehensive tests, and full documentation for the Nisse Gradle plugin.

### Changes

**New: `nisseConfig` DSL extension**

```groovy
nisseConfig {
    jgit {
        countingVersion = true
        dynamicVersion = true
        appendSnapshot = false
    }
    os {
        active = true
    }
}
```

**Plugin changes:**
- `NisseExtension.java` — Gradle DSL with nested `JGitExtension` and `OsExtension`, covering all `nisse.source.*` config options
- `NissePlugin.java` — defers `nisse` extension creation to `afterEvaluate` so DSL block is processed first
- `NisseValueSource.java` / `NisseValueSourceParam.java` — pass DSL user properties into `SimpleNisseConfiguration`

**Tests (8 total, 6 new):**
- `minimalSetup` — just apply the plugin, access OS properties
- `configureDeactivateSource` — deactivate jgit via DSL
- `configureJgitViaDsl` — configure dynamicVersion, appendDirty, etc.
- `configureCountingVersion` — counting version with commit directives (`[major]`, `[minor]`)
- `configureCountingVersionCustomPattern` — custom start values and pattern
- `configureUseInProjectVersion` — use counting version as `project.version`

**Documentation:**
- New `gradle/README.md` with full property reference, DSL options, dynamic/counting version docs, examples
- Root `README.md` links to Gradle plugin docs