### PR TITLE
Fix gradle plugin to be Java 8 as the rest of Nisse suite

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.3")
 }
 
+tasks.compileJava {
+    options.release.set(8)
+}
+
 tasks.named('test', Test) {
     useJUnitPlatform()
 


### PR DESCRIPTION
Here in Maveniverse we always build with Java 21 but that does not mean we target it for that as well. This project is in fact Java 8, so add that info to gradle build.

It seems gradle uses "by default" the Java level that project is built with?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Java compilation configuration to target Java 8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/nisse/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->