### PR TITLE
Include remote info as well

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -36,6 +37,8 @@ import org.eclipse.aether.version.VersionScheme;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.lib.ConfigConstants;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
@@ -72,6 +75,10 @@ public class JGitPropertySource implements PropertySource {
     private static final String JGIT_CLEAN = "clean";
 
     private static final String JGIT_BRANCH_NAME = "branchName";
+
+    private static final String JGIT_REMOTE_NAME = "remoteName";
+
+    private static final String JGIT_REMOTE_URL = "remoteUrl";
 
     /**
      * Specify the length for the short commit id.
@@ -241,9 +248,26 @@ public class JGitPropertySource implements PropertySource {
      */
     protected final String defaultVersion = "0.1.0";
 
+    /**
+     * Configure the list of remote names you are interested in (in order).
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_REMOTE_NAMES = "nisse.source.jgit.remoteNames";
+
+    /**
+     * The default remote names.
+     */
+    private static final String DEFAULT_REMOTE_NAMES = "upstream,origin";
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final VersionScheme versionScheme = new GenericVersionScheme();
+
+    private static List<String> csv(String csv) {
+        if (csv == null || csv.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(csv.split("[,;|]"));
+    }
 
     @Override
     public String getName() {
@@ -296,6 +320,20 @@ public class JGitPropertySource implements PropertySource {
                             JGIT_AUTHOR,
                             lastCommit.getAuthorIdent().toExternalString().split(">")[0] + ">");
                     result.put(JGIT_CLEAN, Boolean.toString(isClean(git)));
+
+                    Config config = repository.getConfig();
+                    List<String> wantedRemotes = csv(configuration
+                            .getConfiguration()
+                            .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_REMOTE_NAMES, DEFAULT_REMOTE_NAMES));
+                    for (String remote : wantedRemotes) {
+                        String url = config.getString(
+                                ConfigConstants.CONFIG_REMOTE_SECTION, remote, ConfigConstants.CONFIG_KEY_URL);
+                        if (url != null && !url.trim().isEmpty()) {
+                            result.put(JGIT_REMOTE_NAME, remote);
+                            result.put(JGIT_REMOTE_URL, url);
+                            break;
+                        }
+                    }
 
                     Optional<Ref> localBranch = localBranch(git, head);
                     localBranch

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -266,7 +266,10 @@ public class JGitPropertySource implements PropertySource {
         if (csv == null || csv.trim().isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.asList(csv.split("[,;|]"));
+        return Arrays.stream(csv.split("[,;|]"))
+                .map(String::trim)
+                .filter(name -> !name.isEmpty())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Named;
@@ -244,6 +245,13 @@ public class JGitPropertySource implements PropertySource {
     protected static final Pattern TAG_VERSION_PATTERN = Pattern.compile("refs/tags/v?((\\d+\\.\\d+\\.\\d+)(.*))");
 
     /**
+     * Matches the credential-bearing userinfo (user, or user:password) in an HTTP(S) remote URL,
+     * e.g. {@code https://user:token@host/repo.git}. SSH-style URLs (scp-like {@code git@host:path}
+     * or {@code ssh://user@host/path}) never match, since they carry no scheme or a non-http(s) one.
+     */
+    private static final Pattern HTTP_CREDENTIAL_PATTERN = Pattern.compile("^(https?://)[^/@]+@(.*)$");
+
+    /**
      * The default version if no version can be determined from git.
      */
     protected final String defaultVersion = "0.1.0";
@@ -262,6 +270,10 @@ public class JGitPropertySource implements PropertySource {
 
     private final VersionScheme versionScheme = new GenericVersionScheme();
 
+    /**
+     * Splits incoming string at comma, semicolon or pipe character, and after trimming and filtering
+     * for empty strings, returns the resulted list of strings.
+     */
     private static List<String> csv(String csv) {
         if (csv == null || csv.trim().isEmpty()) {
             return Collections.emptyList();
@@ -270,6 +282,16 @@ public class JGitPropertySource implements PropertySource {
                 .map(String::trim)
                 .filter(name -> !name.isEmpty())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Strips {@code user:password@}/{@code user@} userinfo from HTTP(S) remote URLs so credentials
+     * never leak into build properties. SSH-style URLs (scp-like or {@code ssh://}) are left untouched,
+     * since their userinfo is at most a login name, never a secret.
+     */
+    static String redactCredentials(String url) {
+        Matcher m = HTTP_CREDENTIAL_PATTERN.matcher(url);
+        return m.matches() ? m.group(1) + m.group(2) : url;
     }
 
     @Override
@@ -329,11 +351,14 @@ public class JGitPropertySource implements PropertySource {
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_REMOTE_NAMES, DEFAULT_REMOTE_NAMES));
                     for (String remote : wantedRemotes) {
-                        String url = config.getString(
-                                ConfigConstants.CONFIG_REMOTE_SECTION, remote, ConfigConstants.CONFIG_KEY_URL);
+                        String url = Arrays.stream(config.getStringList(
+                                        ConfigConstants.CONFIG_REMOTE_SECTION, remote, ConfigConstants.CONFIG_KEY_URL))
+                                .filter(value -> value != null && !value.trim().isEmpty())
+                                .findFirst()
+                                .orElse(null);
                         if (url != null && !url.trim().isEmpty()) {
                             result.put(JGIT_REMOTE_NAME, remote);
-                            result.put(JGIT_REMOTE_URL, url);
+                            result.put(JGIT_REMOTE_URL, redactCredentials(url));
                             break;
                         }
                     }

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -123,6 +123,63 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testRedactCredentialsHttpsUserAndPassword() {
+        assertEquals(
+                "https://github.com/example/repo.git",
+                JGitPropertySource.redactCredentials("https://user:s3cr3t@github.com/example/repo.git"));
+    }
+
+    @Test
+    void testRedactCredentialsHttpsUserOnly() {
+        assertEquals(
+                "https://github.com/example/repo.git",
+                JGitPropertySource.redactCredentials("https://token@github.com/example/repo.git"));
+    }
+
+    @Test
+    void testRedactCredentialsPlainHttpsUnchanged() {
+        assertEquals(
+                "https://github.com/example/repo.git",
+                JGitPropertySource.redactCredentials("https://github.com/example/repo.git"));
+    }
+
+    @Test
+    void testRedactCredentialsScpStyleSshUnchanged() {
+        assertEquals(
+                "git@github.com:example/repo.git",
+                JGitPropertySource.redactCredentials("git@github.com:example/repo.git"));
+    }
+
+    @Test
+    void testRedactCredentialsSshUriUnchanged() {
+        assertEquals(
+                "ssh://git@github.com/example/repo.git",
+                JGitPropertySource.redactCredentials("ssh://git@github.com/example/repo.git"));
+    }
+
+    @Test
+    void testRemoteUrlRedactedFromProperties(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init", "-b", "master");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file.txt");
+        exec(mainRepo, "git", "commit", "-m", "initial commit");
+        exec(mainRepo, "git", "remote", "add", "origin", "https://user:s3cr3t@example.com/example/repo.git");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertEquals("https://example.com/example/repo.git", properties.get("remoteUrl"));
+        assertFalse(properties.get("remoteUrl").contains("s3cr3t"));
+    }
+
+    @Test
     void testVersionHintPatternMatching() {
         JGitPropertySource source = new JGitPropertySource();
 


### PR DESCRIPTION
If possible, include remote name and URL too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and detecting Git remote repositories.
  * Supports ordered remote-name lists with comma, semicolon, or pipe separators.
  * Selects the first configured remote with a valid URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->