### PR TITLE
Fix #179: Accept nisse properties from any source in ModelVersionProcessor

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseConfigurationProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseConfigurationProcessor.java
@@ -15,6 +15,7 @@ import eu.maveniverse.maven.nisse.core.PropertyKeyNamingStrategies;
 import eu.maveniverse.maven.nisse.core.Version;
 import eu.maveniverse.maven.nisse.core.simple.SimpleNisseConfiguration;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import javax.inject.Inject;
@@ -34,13 +35,17 @@ final class NisseConfigurationProcessor implements ConfigurationProcessor {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final NisseManager nisseManager;
     private final SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor;
+    private final NissePropertyKeys nissePropertyKeys;
 
     @Inject
     public NisseConfigurationProcessor(
-            NisseManager nisseManager, SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor) {
+            NisseManager nisseManager,
+            SettingsXmlConfigurationProcessor settingsXmlConfigurationProcessor,
+            NissePropertyKeys nissePropertyKeys) {
         this.nisseManager = requireNonNull(nisseManager, "nisseManager");
         this.settingsXmlConfigurationProcessor =
                 requireNonNull(settingsXmlConfigurationProcessor, "settingsXmlConfigurationProcessor");
+        this.nissePropertyKeys = requireNonNull(nissePropertyKeys, "nissePropertyKeys");
     }
 
     @Override
@@ -76,5 +81,16 @@ final class NisseConfigurationProcessor implements ConfigurationProcessor {
                 request.getUserProperties().setProperty(k, v);
             }
         });
+
+        // Register all nisse-prefixed properties (from any origin: nisse sources, -D flags,
+        // maven-user.properties, export-subst, etc.) so that NisseModelVersionProcessor can
+        // validate them without depending on the MavenSession lifecycle.
+        Map<String, String> allNisseProperties = new HashMap<>(nisseProperties);
+        for (String key : request.getUserProperties().stringPropertyNames()) {
+            if (key.startsWith(NisseConfiguration.PROPERTY_PREFIX)) {
+                allNisseProperties.putIfAbsent(key, request.getUserProperties().getProperty(key));
+            }
+        }
+        nissePropertyKeys.putAll(allNisseProperties);
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
@@ -11,6 +11,8 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -29,20 +31,52 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
     private final Logger logger = LoggerFactory.getLogger(NisseModelVersionProcessor.class);
     private final Provider<MavenSession> sessionProvider;
     private final NissePropertyInliner inliner;
+    private final NissePropertyKeys nissePropertyKeys;
+
+    /**
+     * Keys accepted by {@link #isValidProperty} that could not be registered with the
+     * {@link NissePropertyInliner} because the session was not yet available.
+     * They are flushed into the inliner at the start of {@link #overwriteModelProperties}.
+     */
+    private final Set<String> deferredInlinedKeys = ConcurrentHashMap.newKeySet();
 
     @Inject
-    public NisseModelVersionProcessor(Provider<MavenSession> sessionProvider, NissePropertyInliner inliner) {
+    public NisseModelVersionProcessor(
+            Provider<MavenSession> sessionProvider, NissePropertyInliner inliner, NissePropertyKeys nissePropertyKeys) {
         this.sessionProvider = requireNonNull(sessionProvider, "sessionProvider");
         this.inliner = requireNonNull(inliner, "inliner");
+        this.nissePropertyKeys = requireNonNull(nissePropertyKeys, "nissePropertyKeys");
     }
 
     @Override
     public boolean isValidProperty(String property) {
-        MavenSession session = this.sessionProvider.get();
-        boolean valid = property.startsWith(NisseConfiguration.PROPERTY_PREFIX)
-                && session.getRequest().getUserProperties().containsKey(property);
+        if (!property.startsWith(NisseConfiguration.PROPERTY_PREFIX)) {
+            return false;
+        }
+        // Check the session-independent property registry first. This covers properties
+        // from any nisse source (file, export-subst, maven-user.properties) even when the
+        // jgit source was skipped (e.g. no .git directory in a source archive).
+        boolean valid = nissePropertyKeys.containsKey(property);
+        if (!valid) {
+            // Fallback: check session user properties (covers -D flags set after
+            // NisseConfigurationProcessor ran, or other late-bound properties).
+            try {
+                MavenSession session = sessionProvider.get();
+                valid = session.getRequest().getUserProperties().containsKey(property);
+            } catch (Exception e) {
+                // session not available yet during early model validation
+                logger.debug("NisseModelVersionProcessor.isValidProperty: session not available for {}", property);
+            }
+        }
         if (valid) {
-            inliner.inlinedKeys(session).add(property);
+            try {
+                inliner.inlinedKeys(sessionProvider.get()).add(property);
+            } catch (Exception e) {
+                // Session not available yet; park the key so overwriteModelProperties can
+                // flush it into the inliner once the session exists.
+                deferredInlinedKeys.add(property);
+                logger.debug("NisseModelVersionProcessor.isValidProperty: deferring inlining for {}", property);
+            }
         }
         return valid;
     }
@@ -51,9 +85,24 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
     public void overwriteModelProperties(Properties modelProperties, ModelBuildingRequest request) {
         try {
             MavenSession session = this.sessionProvider.get();
+
+            // Flush any keys that were deferred because the session was unavailable
+            // during isValidProperty.
+            if (!deferredInlinedKeys.isEmpty()) {
+                inliner.inlinedKeys(session).addAll(deferredInlinedKeys);
+                deferredInlinedKeys.clear();
+            }
+
             for (String inlinedKey : inliner.inlinedKeys(session)) {
-                modelProperties.setProperty(
-                        inlinedKey, session.getRequest().getUserProperties().getProperty(inlinedKey));
+                String value = session.getRequest().getUserProperties().getProperty(inlinedKey);
+                if (value == null) {
+                    // Fallback: the property may have been provided by a nisse source
+                    // (e.g. file/export-subst) without going through session user properties.
+                    value = nissePropertyKeys.get(inlinedKey);
+                }
+                if (value != null) {
+                    modelProperties.setProperty(inlinedKey, value);
+                }
             }
         } catch (Exception e) {
             // ignore; this means we were invoked outside of session

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyKeys.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyKeys.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.nisse.extension3.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Shared registry of nisse-managed property keys and their values.
+ * <p>
+ * Populated by {@link NisseConfigurationProcessor} during CLI initialization (before the
+ * Maven session exists). Read by {@link NisseModelVersionProcessor} during model validation
+ * to decide whether a {@code ${nisse.*}} expression is valid in a {@code <version>} element.
+ * <p>
+ * This decouples property validation from the {@code MavenSession} lifecycle, enabling
+ * properties provided by <em>any</em> nisse source (file, export-subst, maven-user.properties)
+ * to be accepted — not just those produced by the jgit source from a live git repository.
+ */
+@Singleton
+@Named
+final class NissePropertyKeys {
+    private final ConcurrentHashMap<String, String> properties = new ConcurrentHashMap<>();
+
+    /**
+     * Register a batch of nisse property keys with their values.
+     */
+    void putAll(Map<String, String> props) {
+        properties.putAll(props);
+    }
+
+    /**
+     * Returns {@code true} if the given key was registered.
+     */
+    boolean containsKey(String key) {
+        return properties.containsKey(key);
+    }
+
+    /**
+     * Returns the value associated with the given key, or {@code null}.
+     */
+    String get(String key) {
+        return properties.get(key);
+    }
+
+    /**
+     * Returns an unmodifiable snapshot of all registered properties.
+     */
+    Map<String, String> getAll() {
+        return Collections.unmodifiableMap(properties);
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessorTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.nisse.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Properties;
+import javax.inject.Provider;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.junit.jupiter.api.Test;
+
+class NisseModelVersionProcessorTest {
+
+    /**
+     * Simulates the scenario from issue #179: no .git directory, but the property
+     * {@code nisse.jgit.dynamicVersion} is available from a file source (export-subst,
+     * maven-user.properties). The ModelVersionProcessor must accept it.
+     */
+    @Test
+    void isValidProperty_acceptsPropertyFromNissePropertyKeys() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        keys.putAll(Collections.singletonMap("nisse.jgit.dynamicVersion", "4.3.1"));
+
+        // Session provider that always throws (simulating session not yet available)
+        Provider<MavenSession> noSession = () -> {
+            throw new IllegalStateException("No session available");
+        };
+
+        NissePropertyInliner inliner = new NissePropertyInliner();
+        NisseModelVersionProcessor processor = new NisseModelVersionProcessor(noSession, inliner, keys);
+
+        assertTrue(processor.isValidProperty("nisse.jgit.dynamicVersion"));
+    }
+
+    /**
+     * Properties not starting with {@code nisse.} are always rejected.
+     */
+    @Test
+    void isValidProperty_rejectsNonNisseProperty() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        Provider<MavenSession> noSession = () -> {
+            throw new IllegalStateException("No session available");
+        };
+        NissePropertyInliner inliner = new NissePropertyInliner();
+        NisseModelVersionProcessor processor = new NisseModelVersionProcessor(noSession, inliner, keys);
+
+        assertFalse(processor.isValidProperty("project.version"));
+        assertFalse(processor.isValidProperty("revision"));
+    }
+
+    /**
+     * Properties not registered in NissePropertyKeys but present in session user properties
+     * (e.g. via {@code -D}) should still be accepted.
+     */
+    @Test
+    void isValidProperty_acceptsPropertyFromSessionUserProperties() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        // keys is empty — property not from any nisse source
+
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        executionRequest.getUserProperties().setProperty("nisse.custom.prop", "value");
+
+        DefaultRepositorySystemSession repoSession = new DefaultRepositorySystemSession();
+        MavenSession session = new MavenSession(null, repoSession, executionRequest, new DefaultMavenExecutionResult());
+        Provider<MavenSession> sessionProvider = () -> session;
+
+        NissePropertyInliner inliner = new NissePropertyInliner();
+        NisseModelVersionProcessor processor = new NisseModelVersionProcessor(sessionProvider, inliner, keys);
+
+        assertTrue(processor.isValidProperty("nisse.custom.prop"));
+    }
+
+    /**
+     * A nisse-prefixed property that exists neither in NissePropertyKeys nor in session
+     * user properties should be rejected.
+     */
+    @Test
+    void isValidProperty_rejectsUnknownNisseProperty() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        DefaultRepositorySystemSession repoSession = new DefaultRepositorySystemSession();
+        MavenSession session = new MavenSession(null, repoSession, executionRequest, new DefaultMavenExecutionResult());
+        Provider<MavenSession> sessionProvider = () -> session;
+
+        NissePropertyInliner inliner = new NissePropertyInliner();
+        NisseModelVersionProcessor processor = new NisseModelVersionProcessor(sessionProvider, inliner, keys);
+
+        assertFalse(processor.isValidProperty("nisse.jgit.nonexistent"));
+    }
+
+    /**
+     * Simulates the full scenario from issue #179:
+     * <ol>
+     *   <li>isValidProperty is called with no session (during early model validation)</li>
+     *   <li>The property is found in NissePropertyKeys and accepted</li>
+     *   <li>Later, overwriteModelProperties is called with a session available</li>
+     *   <li>The deferred key is flushed and the value is taken from NissePropertyKeys</li>
+     * </ol>
+     */
+    @Test
+    void overwriteModelProperties_handlesDeferredInlinedKeys() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        keys.putAll(Collections.singletonMap("nisse.jgit.dynamicVersion", "4.3.1"));
+
+        NissePropertyInliner inliner = new NissePropertyInliner();
+
+        // Phase 1: isValidProperty called when session is NOT available
+        Provider<MavenSession> noSession = () -> {
+            throw new IllegalStateException("No session available");
+        };
+        NisseModelVersionProcessor processor = new NisseModelVersionProcessor(noSession, inliner, keys);
+        assertTrue(processor.isValidProperty("nisse.jgit.dynamicVersion"));
+
+        // Phase 2: overwriteModelProperties called when session IS available
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        DefaultRepositorySystemSession repoSession = new DefaultRepositorySystemSession();
+        MavenSession session = new MavenSession(null, repoSession, executionRequest, new DefaultMavenExecutionResult());
+
+        // Replace the session provider with a working one via a new processor that shares state.
+        // Since NisseModelVersionProcessor is a singleton, in production the same instance is
+        // called in both phases. We simulate this by using the same processor instance
+        // and providing a session that works for overwriteModelProperties.
+        // We need to use reflection or a workaround since the provider is final.
+        // Instead, let's create a mutable provider:
+        MutableSessionProvider mutableProvider = new MutableSessionProvider();
+        NisseModelVersionProcessor processor2 = new NisseModelVersionProcessor(mutableProvider, inliner, keys);
+
+        // Phase 1: no session — isValidProperty defers the key
+        assertTrue(processor2.isValidProperty("nisse.jgit.dynamicVersion"));
+
+        // Phase 2: session becomes available
+        mutableProvider.setSession(session);
+
+        Properties modelProperties = new Properties();
+        processor2.overwriteModelProperties(modelProperties, null);
+
+        assertTrue(modelProperties.containsKey("nisse.jgit.dynamicVersion"));
+        assertEquals("4.3.1", modelProperties.getProperty("nisse.jgit.dynamicVersion"));
+    }
+
+    /**
+     * When both session and NissePropertyKeys have the value, session takes precedence.
+     */
+    @Test
+    void overwriteModelProperties_sessionTakesPrecedence() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        keys.putAll(Collections.singletonMap("nisse.jgit.dynamicVersion", "from-file"));
+
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        executionRequest.getUserProperties().setProperty("nisse.jgit.dynamicVersion", "from-session");
+
+        DefaultRepositorySystemSession repoSession = new DefaultRepositorySystemSession();
+        MavenSession session = new MavenSession(null, repoSession, executionRequest, new DefaultMavenExecutionResult());
+        Provider<MavenSession> sessionProvider = () -> session;
+
+        NissePropertyInliner inliner = new NissePropertyInliner();
+        NisseModelVersionProcessor processor = new NisseModelVersionProcessor(sessionProvider, inliner, keys);
+
+        assertTrue(processor.isValidProperty("nisse.jgit.dynamicVersion"));
+
+        Properties modelProperties = new Properties();
+        processor.overwriteModelProperties(modelProperties, null);
+
+        assertEquals("from-session", modelProperties.getProperty("nisse.jgit.dynamicVersion"));
+    }
+
+    /**
+     * A mutable Provider that can switch between "no session" and "session available"
+     * states, simulating the Maven lifecycle where the session becomes available after
+     * model validation.
+     */
+    private static class MutableSessionProvider implements Provider<MavenSession> {
+        private volatile MavenSession session;
+
+        void setSession(MavenSession session) {
+            this.session = session;
+        }
+
+        @Override
+        public MavenSession get() {
+            MavenSession s = session;
+            if (s == null) {
+                throw new IllegalStateException("No session available");
+            }
+            return s;
+        }
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyKeysTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/nisse/extension3/internal/NissePropertyKeysTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.nisse.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NissePropertyKeysTest {
+
+    @Test
+    void emptyRegistryContainsNothing() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        assertFalse(keys.containsKey("nisse.jgit.dynamicVersion"));
+        assertNull(keys.get("nisse.jgit.dynamicVersion"));
+        assertTrue(keys.getAll().isEmpty());
+    }
+
+    @Test
+    void putAllRegistersProperties() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        Map<String, String> props = new HashMap<>();
+        props.put("nisse.jgit.dynamicVersion", "4.3.1");
+        props.put("nisse.jgit.commit", "abc123");
+
+        keys.putAll(props);
+
+        assertTrue(keys.containsKey("nisse.jgit.dynamicVersion"));
+        assertEquals("4.3.1", keys.get("nisse.jgit.dynamicVersion"));
+        assertTrue(keys.containsKey("nisse.jgit.commit"));
+        assertEquals("abc123", keys.get("nisse.jgit.commit"));
+        assertFalse(keys.containsKey("nisse.jgit.nonexistent"));
+    }
+
+    @Test
+    void getAllReturnsSnapshot() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        Map<String, String> props = new HashMap<>();
+        props.put("nisse.os.name", "linux");
+        keys.putAll(props);
+
+        Map<String, String> all = keys.getAll();
+        assertEquals(1, all.size());
+        assertEquals("linux", all.get("nisse.os.name"));
+    }
+
+    @Test
+    void putAllMergesWithExisting() {
+        NissePropertyKeys keys = new NissePropertyKeys();
+        Map<String, String> first = new HashMap<>();
+        first.put("nisse.jgit.dynamicVersion", "1.0.0");
+        keys.putAll(first);
+
+        Map<String, String> second = new HashMap<>();
+        second.put("nisse.os.name", "linux");
+        second.put("nisse.jgit.dynamicVersion", "2.0.0"); // overwrites
+        keys.putAll(second);
+
+        assertEquals("2.0.0", keys.get("nisse.jgit.dynamicVersion"));
+        assertEquals("linux", keys.get("nisse.os.name"));
+        assertEquals(2, keys.getAll().size());
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `NissePropertyKeys`, a session-independent registry that stores all nisse-managed property keys and values during CLI initialization
- `NisseConfigurationProcessor` now populates this registry with all `nisse.*` properties from any origin (nisse sources, `-D` flags, maven-user.properties, export-subst)
- `NisseModelVersionProcessor.isValidProperty()` checks the registry first, then falls back to session user properties — enabling `${nisse.jgit.dynamicVersion}` in `<version>` even when there's no `.git` directory
- Deferred inlined keys (accepted before the session was available) are flushed into the inliner when `overwriteModelProperties` runs
- Added 10 unit tests covering: property acceptance from any source, session-unavailable scenarios, deferred inlining, and precedence rules

Fixes #179

## Test plan
- [x] All 10 new unit tests pass (NissePropertyKeysTest + NisseModelVersionProcessorTest)
- [x] Full project build passes (`mvn clean install -B`)
- [ ] Manual test: build JLine from source archive without `.git` directory (as described in #179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of Nisse-prefixed properties across configuration and model processing.
  * Added support for resolving property values from both session settings and user-provided properties.
  * Preserved property processing when Maven session details are temporarily unavailable.

* **Bug Fixes**
  * Improved property precedence and validation, ensuring recognized values are applied consistently.

* **Tests**
  * Added coverage for property registration, lookup, merging, validation, deferred processing, and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->