### PR TITLE
fix: use put instead of putIfAbsent in extension4 PropertyContributor for Maven 4 compatibility

### DIFF
--- a/extension4/src/main/java/eu/maveniverse/maven/nisse/extension4/internal/NissePropertyContributor.java
+++ b/extension4/src/main/java/eu/maveniverse/maven/nisse/extension4/internal/NissePropertyContributor.java
@@ -61,7 +61,12 @@ final class NissePropertyContributor implements PropertyContributor {
             if (Boolean.parseBoolean(protoSession.getUserProperties().getOrDefault("nisse.dump", "false"))) {
                 nisseProperties.forEach((k, v) -> logger.info("{}={}", k, v));
             }
-            nisseProperties.forEach(result::putIfAbsent);
+            // Use put (not putIfAbsent) so Nisse-computed values always take precedence.
+            // Maven 4 auto-loads .mvn/maven-user.properties before extensions run, which
+            // pre-populates keys (e.g. nisse.jgit.dynamicVersion) with unexpanded export-subst
+            // placeholders like "$Format:%(describe:tags=true)$". putIfAbsent would keep the
+            // placeholder, causing Maven 4's strict POM validation to reject it.
+            nisseProperties.forEach(result::put);
             return result;
         } catch (IOException e) {
             throw new UncheckedIOException("Error while creating Nisse configuration", e);

--- a/it/extension3-its/src/it/user-props-override/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/user-props-override/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/user-props-override/.mvn/maven-user.properties
+++ b/it/extension3-its/src/it/user-props-override/.mvn/maven-user.properties
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Simulates the export-subst scenario: this file contains a stale placeholder.
+# Maven 3 does NOT auto-load maven-user.properties into user properties, so
+# the containsKey guard in extension3 will not find this key and Nisse will
+# inject its computed value normally.
+nisse.file.one=stale-placeholder

--- a/it/extension3-its/src/it/user-props-override/.mvn/maven.config
+++ b/it/extension3-its/src/it/user-props-override/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.file.name=${session.rootDirectory}/build.properties

--- a/it/extension3-its/src/it/user-props-override/build.properties
+++ b/it/extension3-its/src/it/user-props-override/build.properties
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Nisse file source: the computed value that must be injected
+one=fresh-computed

--- a/it/extension3-its/src/it/user-props-override/invoker.properties
+++ b/it/extension3-its/src/it/user-props-override/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = -V help:evaluate -Dexpression=nisse.file.one -Dnisse.dump

--- a/it/extension3-its/src/it/user-props-override/pom.xml
+++ b/it/extension3-its/src/it/user-props-override/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.user-props-override</groupId>
+    <artifactId>user-props-override</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/user-props-override/verify.groovy
+++ b/it/extension3-its/src/it/user-props-override/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verifies that Nisse-computed properties are injected even when
+// .mvn/maven-user.properties exists with a stale value. Maven 3 does NOT
+// auto-load maven-user.properties into user properties, so the containsKey
+// guard in extension3 will not find the key and Nisse injects its computed
+// value normally.
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+String buildLogText = buildLog.text
+
+// The Nisse file source must have injected its computed value
+assert buildLogText.contains( 'nisse.file.one=fresh-computed' ) : \
+    'Nisse-computed value "fresh-computed" not found in build log'
+
+// The stale placeholder from maven-user.properties must NOT appear as the resolved value
+assert !buildLogText.contains( 'nisse.file.one=stale-placeholder' ) : \
+    'Stale placeholder from maven-user.properties leaked into Nisse properties'

--- a/it/extension4-its/src/it/user-props-override/.mvn/extensions.xml
+++ b/it/extension4-its/src/it/user-props-override/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension4</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension4-its/src/it/user-props-override/.mvn/maven-user.properties
+++ b/it/extension4-its/src/it/user-props-override/.mvn/maven-user.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Simulates the export-subst scenario: Maven 4 auto-loads this file before
+# extensions run, pre-populating user properties with stale placeholder values.
+# Nisse-computed values must override these.
+nisse.file.one=stale-placeholder

--- a/it/extension4-its/src/it/user-props-override/.mvn/maven.config
+++ b/it/extension4-its/src/it/user-props-override/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.file.name=${session.rootDirectory}/build.properties

--- a/it/extension4-its/src/it/user-props-override/build.properties
+++ b/it/extension4-its/src/it/user-props-override/build.properties
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Nisse file source: the computed value that must override the stale
+# placeholder from maven-user.properties
+one=fresh-computed

--- a/it/extension4-its/src/it/user-props-override/invoker.properties
+++ b/it/extension4-its/src/it/user-props-override/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = -V help:evaluate -Dexpression=nisse.file.one -Dnisse.dump

--- a/it/extension4-its/src/it/user-props-override/pom.xml
+++ b/it/extension4-its/src/it/user-props-override/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.user-props-override</groupId>
+    <artifactId>user-props-override</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+</project>

--- a/it/extension4-its/src/it/user-props-override/verify.groovy
+++ b/it/extension4-its/src/it/user-props-override/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verifies that Nisse-computed properties override values pre-loaded from
+// .mvn/maven-user.properties. Maven 4 auto-loads that file before extensions
+// run, so without the put (vs putIfAbsent) fix, the stale placeholder would
+// persist and Nisse's computed value would be ignored.
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+String buildLogText = buildLog.text
+
+// The Nisse file source must have injected its computed value
+assert buildLogText.contains( 'nisse.file.one=fresh-computed' ) : \
+    'Nisse-computed value "fresh-computed" not found in build log — put override failed'
+
+// The stale placeholder from maven-user.properties must NOT appear as the resolved value
+assert !buildLogText.contains( 'nisse.file.one=stale-placeholder' ) : \
+    'Stale placeholder from maven-user.properties was not overridden by Nisse'


### PR DESCRIPTION
## Summary

- **Fix Maven 4 compatibility** in `extension4` `NissePropertyContributor`: change `putIfAbsent` to `put` when merging Nisse-computed properties into user properties.
- Maven 4 auto-loads `.mvn/maven-user.properties` before extensions run, pre-populating `nisse.jgit.dynamicVersion` with the unexpanded `export-subst` placeholder `$Format:%(describe:tags=true)$`. Since `putIfAbsent` won't override the pre-loaded value, the version resolves to the placeholder (which contains `:`), and Maven 4's strict POM validation rejects it.
- Using `put` ensures Nisse-computed values always take precedence over pre-loaded placeholder values.

Ref: maveniverse/scalpel#62

## Test plan

- [ ] Verify `extension4` module compiles cleanly
- [ ] Test with Maven 4 + export-subst in `.mvn/maven-user.properties` — Nisse-computed values should override pre-loaded placeholders
- [ ] Test with Maven 3 — behavior should be unchanged (nisse properties still injected correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)