### PR TITLE
Support .mvn/nisse.properties as low-priority fallback

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManager.java
@@ -12,17 +12,38 @@ import static java.util.Objects.requireNonNull;
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import eu.maveniverse.maven.nisse.core.NisseManager;
 import eu.maveniverse.maven.nisse.core.PropertySource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.BiFunction;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 @Named
 public class SimpleNisseManager implements NisseManager {
+
+    /**
+     * The name of the low-priority fallback properties file, expected under the {@code .mvn/}
+     * directory of the session root. Properties from this file are loaded before any
+     * {@link PropertySource} so that source-resolved values (e.g. from JGit) take precedence.
+     * <p>
+     * The primary use case is source-archive builds (no {@code .git} directory) combined with
+     * git {@code export-subst}: placeholders like {@code $Format:%(describe:tags=true)$} in
+     * this file are expanded by {@code git archive}, providing fallback values when JGit
+     * cannot resolve them.
+     */
+    static final String NISSE_PROPERTIES_FILE = ".mvn/nisse.properties";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final List<PropertySource> sources;
 
     @Inject
@@ -36,6 +57,11 @@ public class SimpleNisseManager implements NisseManager {
         BiFunction<PropertySource, String, List<String>> propertyKeyNamingStrategy =
                 configuration.propertyKeyNamingStrategy();
         HashMap<String, String> properties = new HashMap<>();
+
+        // Load .mvn/nisse.properties as a low-priority fallback: these values are
+        // placed first so that PropertySource results (e.g. JGit) overwrite them.
+        loadFallbackProperties(configuration, properties);
+
         for (PropertySource source : this.sources) {
             if (configuration.isPropertySourceActive(source)) {
                 source.getProperties(configuration).forEach((key, value) -> {
@@ -46,5 +72,48 @@ public class SimpleNisseManager implements NisseManager {
             }
         }
         return properties;
+    }
+
+    /**
+     * Loads properties from {@code .mvn/nisse.properties} relative to the session root directory.
+     * Values that look like unexpanded git {@code export-subst} placeholders
+     * ({@code $Format:…$}) are silently skipped.
+     */
+    private void loadFallbackProperties(NisseConfiguration configuration, Map<String, String> target) {
+        Path nissePropertiesPath = configuration.getSessionRootDirectory().resolve(NISSE_PROPERTIES_FILE);
+        if (!Files.isRegularFile(nissePropertiesPath)) {
+            return;
+        }
+        try (InputStream in = Files.newInputStream(nissePropertiesPath)) {
+            Properties props = new Properties();
+            props.load(in);
+            int loaded = 0;
+            int skipped = 0;
+            for (String key : props.stringPropertyNames()) {
+                String value = props.getProperty(key);
+                if (isUnexpandedPlaceholder(value)) {
+                    skipped++;
+                    logger.debug("Skipping unexpanded export-subst placeholder: {}={}", key, value);
+                } else {
+                    target.put(key, value);
+                    loaded++;
+                }
+            }
+            logger.debug(
+                    "Loaded {} fallback properties from {} ({} unexpanded placeholders skipped)",
+                    loaded,
+                    nissePropertiesPath,
+                    skipped);
+        } catch (IOException e) {
+            logger.warn("Failed to read fallback properties from {}: {}", nissePropertiesPath, e.getMessage());
+        }
+    }
+
+    /**
+     * Returns {@code true} if the value looks like an unexpanded git {@code export-subst}
+     * placeholder, i.e. it matches the pattern {@code $Format:…$}.
+     */
+    static boolean isUnexpandedPlaceholder(String value) {
+        return value != null && value.startsWith("$Format:") && value.endsWith("$");
     }
 }

--- a/core/src/main/java9/module-info.java
+++ b/core/src/main/java9/module-info.java
@@ -7,6 +7,7 @@
  */
 module eu.maveniverse.maven.nisse.core {
     requires java.base;
+    requires org.slf4j;
 
     exports eu.maveniverse.maven.nisse.core;
     exports eu.maveniverse.maven.nisse.core.simple;

--- a/core/src/test/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManagerTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManagerTest.java
@@ -1,16 +1,22 @@
 package eu.maveniverse.maven.nisse.core.simple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
 import eu.maveniverse.maven.nisse.core.PropertySource;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class SimpleNisseManagerTest {
     @Test
@@ -57,5 +63,143 @@ public class SimpleNisseManagerTest {
         assertSame(allProperties.get("nisse.hu.one"), "egy");
         assertTrue(allProperties.containsKey("nisse.hu.two"));
         assertSame(allProperties.get("nisse.hu.two"), "kettő");
+    }
+
+    @Test
+    void fallbackPropertiesAreLoaded(@TempDir Path tempDir) throws IOException {
+        // Set up .mvn/nisse.properties
+        Path mvnDir = tempDir.resolve(".mvn");
+        Files.createDirectories(mvnDir);
+        Properties fallbackProps = new Properties();
+        fallbackProps.setProperty("nisse.jgit.dynamicVersion", "1.2.3");
+        fallbackProps.setProperty("nisse.jgit.date", "2024-01-01T00:00:00Z");
+        writeProperties(mvnDir.resolve("nisse.properties"), fallbackProps);
+
+        SimpleNisseManager snm = new SimpleNisseManager(Arrays.asList());
+
+        SimpleNisseConfiguration conf = SimpleNisseConfiguration.builder()
+                .withSessionRootDirectory(tempDir)
+                .build();
+
+        Map<String, String> allProperties = snm.createProperties(conf);
+        assertEquals(2, allProperties.size());
+        assertEquals("1.2.3", allProperties.get("nisse.jgit.dynamicVersion"));
+        assertEquals("2024-01-01T00:00:00Z", allProperties.get("nisse.jgit.date"));
+    }
+
+    @Test
+    void propertySourcesOverrideFallback(@TempDir Path tempDir) throws IOException {
+        // Set up .mvn/nisse.properties with fallback values
+        Path mvnDir = tempDir.resolve(".mvn");
+        Files.createDirectories(mvnDir);
+        Properties fallbackProps = new Properties();
+        fallbackProps.setProperty("nisse.test.key1", "fallback-value");
+        fallbackProps.setProperty("nisse.test.key2", "only-in-fallback");
+        writeProperties(mvnDir.resolve("nisse.properties"), fallbackProps);
+
+        // PropertySource that produces nisse.test.key1 (should override fallback)
+        PropertySource source = new PropertySource() {
+            @Override
+            public String getName() {
+                return "test";
+            }
+
+            @Override
+            public Map<String, String> getProperties(NisseConfiguration configuration) {
+                Map<String, String> props = new HashMap<>();
+                props.put("key1", "source-value");
+                return props;
+            }
+        };
+
+        SimpleNisseManager snm = new SimpleNisseManager(Arrays.asList(source));
+
+        SimpleNisseConfiguration conf = SimpleNisseConfiguration.builder()
+                .withSessionRootDirectory(tempDir)
+                .build();
+
+        Map<String, String> allProperties = snm.createProperties(conf);
+        // source value should override fallback
+        assertEquals("source-value", allProperties.get("nisse.test.key1"));
+        // fallback-only value should be preserved
+        assertEquals("only-in-fallback", allProperties.get("nisse.test.key2"));
+    }
+
+    @Test
+    void unexpandedPlaceholdersAreSkipped(@TempDir Path tempDir) throws IOException {
+        // Set up .mvn/nisse.properties with unexpanded export-subst placeholders
+        Path mvnDir = tempDir.resolve(".mvn");
+        Files.createDirectories(mvnDir);
+        Properties fallbackProps = new Properties();
+        fallbackProps.setProperty("nisse.jgit.dynamicVersion", "$Format:%(describe:tags=true)$");
+        fallbackProps.setProperty("nisse.jgit.date", "$Format:%cI$");
+        fallbackProps.setProperty("nisse.jgit.commit", "abc123"); // valid expanded value
+        writeProperties(mvnDir.resolve("nisse.properties"), fallbackProps);
+
+        SimpleNisseManager snm = new SimpleNisseManager(Arrays.asList());
+
+        SimpleNisseConfiguration conf = SimpleNisseConfiguration.builder()
+                .withSessionRootDirectory(tempDir)
+                .build();
+
+        Map<String, String> allProperties = snm.createProperties(conf);
+        // unexpanded placeholders should be skipped
+        assertFalse(allProperties.containsKey("nisse.jgit.dynamicVersion"));
+        assertFalse(allProperties.containsKey("nisse.jgit.date"));
+        // valid value should be loaded
+        assertEquals("abc123", allProperties.get("nisse.jgit.commit"));
+    }
+
+    @Test
+    void missingNissePropertiesFileIsIgnored(@TempDir Path tempDir) throws IOException {
+        // No .mvn/nisse.properties file exists
+        SimpleNisseManager snm = new SimpleNisseManager(Arrays.asList());
+
+        SimpleNisseConfiguration conf = SimpleNisseConfiguration.builder()
+                .withSessionRootDirectory(tempDir)
+                .build();
+
+        Map<String, String> allProperties = snm.createProperties(conf);
+        assertTrue(allProperties.isEmpty());
+    }
+
+    @Test
+    void isUnexpandedPlaceholder() {
+        assertTrue(SimpleNisseManager.isUnexpandedPlaceholder("$Format:%(describe:tags=true)$"));
+        assertTrue(SimpleNisseManager.isUnexpandedPlaceholder("$Format:%cI$"));
+        assertTrue(SimpleNisseManager.isUnexpandedPlaceholder("$Format:%H$"));
+
+        assertFalse(SimpleNisseManager.isUnexpandedPlaceholder("1.2.3"));
+        assertFalse(SimpleNisseManager.isUnexpandedPlaceholder(""));
+        assertFalse(SimpleNisseManager.isUnexpandedPlaceholder(null));
+        assertFalse(SimpleNisseManager.isUnexpandedPlaceholder("some-value-with-$dollar"));
+        assertFalse(SimpleNisseManager.isUnexpandedPlaceholder("$NotFormat:something$"));
+    }
+
+    @Test
+    void expandedPlaceholderValuesAreLoaded(@TempDir Path tempDir) throws IOException {
+        // Simulate what git archive produces: expanded export-subst values
+        Path mvnDir = tempDir.resolve(".mvn");
+        Files.createDirectories(mvnDir);
+        Properties fallbackProps = new Properties();
+        fallbackProps.setProperty("nisse.jgit.dynamicVersion", "v1.0.0-3-g1234567");
+        fallbackProps.setProperty("nisse.jgit.date", "2024-06-15T10:30:00+02:00");
+        writeProperties(mvnDir.resolve("nisse.properties"), fallbackProps);
+
+        SimpleNisseManager snm = new SimpleNisseManager(Arrays.asList());
+
+        SimpleNisseConfiguration conf = SimpleNisseConfiguration.builder()
+                .withSessionRootDirectory(tempDir)
+                .build();
+
+        Map<String, String> allProperties = snm.createProperties(conf);
+        assertEquals("v1.0.0-3-g1234567", allProperties.get("nisse.jgit.dynamicVersion"));
+        assertEquals("2024-06-15T10:30:00+02:00", allProperties.get("nisse.jgit.date"));
+    }
+
+    private static void writeProperties(Path path, Properties props) throws IOException {
+        try (OutputStream out = Files.newOutputStream(path)) {
+            props.store(out, null);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #182.

- Reads `.mvn/nisse.properties` from the session root directory as a low-priority fallback property source in `SimpleNisseManager.createProperties()`
- Fallback values are loaded **before** any `PropertySource`, so JGit-resolved values take precedence; CLI `-D` properties remain highest priority
- Unexpanded git `export-subst` placeholders (`$Format:…$`) are detected and silently skipped to avoid injecting literal placeholder strings
- Adds `slf4j-api` as a `provided` dependency to the core module for logging

### Priority order

| Priority | Source |
|---|---|
| Highest | CLI `-D` / `maven.config` |
| High | JGit-resolved properties |
| **Low** | **`.mvn/nisse.properties`** ← new |

### Usage with `export-subst`

`.gitattributes`:
```
.mvn/nisse.properties export-subst
```

`.mvn/nisse.properties`:
```properties
nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
nisse.jgit.date=$Format:%cI$
```

- **Git checkout:** JGit resolves the real values → `nisse.properties` is ignored (lower priority)
- **Source archive:** `git archive` expands the `$Format:…$` placeholders → nisse falls back to the expanded values

## Test plan

- [x] Unit test: fallback properties are loaded from `.mvn/nisse.properties`
- [x] Unit test: PropertySource values override fallback values
- [x] Unit test: unexpanded `$Format:…$` placeholders are skipped
- [x] Unit test: missing `.mvn/nisse.properties` file is silently ignored
- [x] Unit test: `isUnexpandedPlaceholder()` boundary cases
- [x] Unit test: expanded placeholder values (simulating git archive output) are loaded
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading project properties from `.mvn/nisse.properties`.
  * Existing active property sources take precedence over fallback file values.
  * Unexpanded Git substitution placeholders are safely ignored.

* **Bug Fixes**
  * Improved handling of missing or unreadable property files with informative logging.
  * Expanded placeholders are now loaded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->