### PR TITLE
Allow adding the branch name to dynamic versions

### DIFF
--- a/GIT_CONFIGURATION.md
+++ b/GIT_CONFIGURATION.md
@@ -101,6 +101,12 @@ versions over and over again (the last found tag). Moreover, disabling this feat
 
 If current commit doesn't have a tag, should the count of commits since last tag be appended as build number.
 
+#### `nisse.source.jgit.appendBranchName`
+
+**Default:** `false`
+
+Controls whether to append the name of the actual branch to dynamic versions when the current commit is not tagged.
+
 #### `nisse.source.jgit.appendDirty`
 
 **Default:** `false`

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/maven.config
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/maven.config
@@ -1,0 +1,8 @@
+-D
+nisse.source.jgit.dynamicVersion=true
+-D
+nisse.source.jgit.appendBranchName=true
+-D
+nisse.source.jgit.appendSnapshot=false
+-D
+nisse.source.jgit.increasePatchVersion=false

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/invoker.properties
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2026 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals=-V validate

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/pom.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-dynamic-versioning-branchname-dev</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>it-dynamic-versioning-branchname-dev</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/selector.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/selector.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+try {
+    // smoke test if we have a needed tools
+    def gitVersion = "git --version".execute()
+    gitVersion.consumeProcessOutput(System.out, System.out)
+    gitVersion.waitFor()
+    return gitVersion.exitValue() == 0
+} catch (Exception e) {
+    // some error occurs - we skip a test
+    return false
+}

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/setup.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+void exec(String command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git init')
+exec('git config user.email "you@example.com"')
+exec('git config user.name "Your Name"')
+
+exec('git add test.txt')
+exec('git commit -m initial-commit')
+exec('git tag 1.0.0')
+exec('git tag')
+
+testFile << 'content2'
+exec('git add test.txt')
+exec('git commit -m commit_no2')
+
+testFile << 'content3'
+exec('git add test.txt')
+exec('git commit -m commit_no3')
+
+exec('git checkout -B dev')
+
+testFile << 'content4'
+exec('git add test.txt')
+exec('git commit -m commit_no3')
+
+testFile << 'content5'
+exec('git add test.txt')
+exec('git commit -m commit_no5')

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+// check that property was set
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+// Read the log file
+def logContent = mavenLogFile.text
+
+// Define a pattern to match the version output
+def versionPattern = /\$\{nisse.jgit.dynamicVersion\}=(.+)/
+def matcher = (logContent =~ versionPattern)
+assert matcher.find() : "Version information not found in log file"
+
+// Extract the version from the matched group
+def actualVersion = matcher[0][1]
+
+def expectedVersion = '1.0.0-4-dev'
+
+assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'"

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/maven.config
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/maven.config
@@ -1,0 +1,8 @@
+-D
+nisse.source.jgit.dynamicVersion=true
+-D
+nisse.source.jgit.appendBranchName=true
+-D
+nisse.source.jgit.appendSnapshot=false
+-D
+nisse.source.jgit.increasePatchVersion=false

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/invoker.properties
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2026 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals=-V validate 

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/pom.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-dynamic-versioning-branchname-master</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>it-dynamic-versioning-branchname-master</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/selector.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/selector.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+try {
+    // smoke test if we have a needed tools
+    def gitVersion = "git --version".execute()
+    gitVersion.consumeProcessOutput(System.out, System.out)
+    gitVersion.waitFor()
+    return gitVersion.exitValue() == 0
+} catch (Exception e) {
+    // some error occurs - we skip a test
+    return false
+}

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+void exec(String command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git init')
+exec('git config user.email "you@example.com"')
+exec('git config user.name "Your Name"')
+
+exec('git add test.txt')
+exec('git commit -m initial-commit')
+exec('git tag 1.0.0')
+exec('git tag')
+
+testFile << 'content2'
+exec('git add test.txt')
+exec('git commit -m commit_no2')
+
+testFile << 'content3'
+exec('git add test.txt')
+exec('git commit -m commit_no3')
+
+testFile << 'content4'
+exec('git add test.txt')
+exec('git commit -m commit_no4')

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+// check that property was set
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+// Read the log file
+def logContent = mavenLogFile.text
+
+// Define a pattern to match the version output
+def versionPattern = /\$\{nisse.jgit.dynamicVersion\}=(.+)/
+def matcher = (logContent =~ versionPattern)
+assert matcher.find() : "Version information not found in log file"
+
+// Extract the version from the matched group
+def actualVersion = matcher[0][1]
+
+def expectedVersion = '1.0.0-3-master'
+
+assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'"

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -709,7 +709,7 @@ public class JGitPropertySource implements PropertySource {
                 }
                 count++;
             }
-            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), null);
+            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), head);
         } catch (GitAPIException e) {
             throw new Exception("Error reading Git information.", e);
         }
@@ -778,7 +778,7 @@ public class JGitPropertySource implements PropertySource {
 
     protected VersionInformation mayAddQualifier(
             NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head)
-            throws GitAPIException, IOException {
+            throws GitAPIException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -777,8 +777,7 @@ public class JGitPropertySource implements PropertySource {
     }
 
     protected VersionInformation mayAddQualifier(
-            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head)
-            throws GitAPIException {
+            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head) throws GitAPIException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -194,6 +194,13 @@ public class JGitPropertySource implements PropertySource {
     private static final String DEFAULT_APPEND_SNAPSHOT = Boolean.TRUE.toString();
 
     /**
+     * Whether the branch name shall be appended or not.
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCHNAME = "nisse.source.jgit.appendBranchName";
+
+    private static final String DEFAULT_APPEND_BRANCH_NAME = Boolean.FALSE.toString();
+
+    /**
      * Whether the DIRTY qualifier shall be appended or not.
      */
     private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_DIRTY = "nisse.source.jgit.appendDirty";
@@ -539,7 +546,7 @@ public class JGitPropertySource implements PropertySource {
 
                 if (isCustomPattern) {
                     // With custom pattern, version hints take priority (git history only contains matching tags)
-                    vi = mayAddQualifier(configuration, git, hintVersion);
+                    vi = mayAddQualifier(configuration, git, hintVersion, head);
                     logger.debug("Using version hint (custom pattern): {}", versionHint.get());
                 } else {
                     // With default pattern, compare versions
@@ -550,7 +557,7 @@ public class JGitPropertySource implements PropertySource {
 
                     if (isDefaultGitVersion) {
                         // No regular release tags found, use version hint directly
-                        vi = mayAddQualifier(configuration, git, hintVersion);
+                        vi = mayAddQualifier(configuration, git, hintVersion, head);
                         logger.debug("Using version hint (no regular release tags found): {}", versionHint.get());
                     } else {
                         // Compare versions - use hint only if it's higher than git history version
@@ -559,7 +566,7 @@ public class JGitPropertySource implements PropertySource {
 
                         if (hintVersionParsed.compareTo(gitHistoryVersionParsed) > 0) {
                             // Version hint is higher, use it
-                            vi = mayAddQualifier(configuration, git, hintVersion);
+                            vi = mayAddQualifier(configuration, git, hintVersion, head);
                             logger.debug("Using version hint (higher than git history): {}", versionHint.get());
                         } else {
                             // Git history version is higher or equal, use it
@@ -694,12 +701,12 @@ public class JGitPropertySource implements PropertySource {
                         if (appendBuildNumber) {
                             vi.setBuildNumber(count);
                         }
-                        return mayAddQualifier(configuration, git, vi);
+                        return mayAddQualifier(configuration, git, vi, head);
                     }
                 }
                 count++;
             }
-            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count));
+            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), null);
         } catch (GitAPIException e) {
             throw new Exception("Error reading Git information.", e);
         }
@@ -766,8 +773,9 @@ public class JGitPropertySource implements PropertySource {
         }
     }
 
-    protected VersionInformation mayAddQualifier(NisseConfiguration configuration, Git git, VersionInformation vi)
-            throws GitAPIException {
+    protected VersionInformation mayAddQualifier(
+            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head)
+            throws GitAPIException, IOException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()
@@ -779,6 +787,15 @@ public class JGitPropertySource implements PropertySource {
                         configuration
                                 .getConfiguration()
                                 .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_DIRTY_QUALIFIER, DEFAULT_DIRTY_QUALIFIER));
+            }
+        }
+        boolean appendBranchName = Boolean.parseBoolean(configuration
+                .getConfiguration()
+                .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCHNAME, DEFAULT_APPEND_BRANCH_NAME));
+        if (appendBranchName) {
+            Optional<String> localBranch = localBranch(git, head).map(r -> Repository.shortenRefName(r.getName()));
+            if (localBranch.isPresent()) {
+                qualifier = appendQualifier(qualifier, localBranch.get());
             }
         }
         boolean appendSnapshot = Boolean.parseBoolean(configuration


### PR DESCRIPTION
Fixes #188.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to append the active Git branch name to dynamic versions for untagged commits.
  * Branch names are shortened and added alongside existing dirty and snapshot qualifiers.
  * The feature is disabled by default and applies during dynamic-version resolution, including fallback versions.

* **Documentation**
  * Added configuration guidance for enabling branch-name version qualifiers.

* **Tests**
  * Added integration coverage verifying branch-qualified versions on `dev` and `master` branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->