### PR TITLE
Branch name qualifier

### DIFF
--- a/GIT_CONFIGURATION.md
+++ b/GIT_CONFIGURATION.md
@@ -101,6 +101,12 @@ versions over and over again (the last found tag). Moreover, disabling this feat
 
 If current commit doesn't have a tag, should the count of commits since last tag be appended as build number.
 
+#### `nisse.source.jgit.appendBranchName`
+
+**Default:** `false`
+
+Controls whether to append the name of the actual branch to dynamic versions when the current commit is not tagged.
+
 #### `nisse.source.jgit.appendDirty`
 
 **Default:** `false`

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/maven.config
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/.mvn/maven.config
@@ -1,0 +1,8 @@
+-D
+nisse.source.jgit.dynamicVersion=true
+-D
+nisse.source.jgit.appendBranchName=true
+-D
+nisse.source.jgit.appendSnapshot=false
+-D
+nisse.source.jgit.increasePatchVersion=false

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/invoker.properties
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2026 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals=-V validate

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/pom.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-dynamic-versioning-branchname-dev</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>it-dynamic-versioning-branchname-dev</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/selector.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/selector.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+try {
+    // smoke test if we have a needed tools
+    def gitVersion = "git --version".execute()
+    gitVersion.consumeProcessOutput(System.out, System.out)
+    gitVersion.waitFor()
+    return gitVersion.exitValue() == 0
+} catch (Exception e) {
+    // some error occurs - we skip a test
+    return false
+}

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/setup.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+void exec(String command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git init')
+exec('git config user.email "you@example.com"')
+exec('git config user.name "Your Name"')
+
+exec('git add test.txt')
+exec('git commit -m initial-commit')
+exec('git tag 1.0.0')
+exec('git tag')
+
+testFile << 'content2'
+exec('git add test.txt')
+exec('git commit -m commit_no2')
+
+testFile << 'content3'
+exec('git add test.txt')
+exec('git commit -m commit_no3')
+
+exec('git checkout -B dev')
+
+testFile << 'content4'
+exec('git add test.txt')
+exec('git commit -m commit_no3')
+
+testFile << 'content5'
+exec('git add test.txt')
+exec('git commit -m commit_no5')

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-dev/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+// check that property was set
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+// Read the log file
+def logContent = mavenLogFile.text
+
+// Define a pattern to match the version output
+def versionPattern = /\$\{nisse.jgit.dynamicVersion\}=(.+)/
+def matcher = (logContent =~ versionPattern)
+assert matcher.find() : "Version information not found in log file"
+
+// Extract the version from the matched group
+def actualVersion = matcher[0][1]
+
+def expectedVersion = '1.0.0-4-dev'
+
+assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'"

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/maven.config
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/.mvn/maven.config
@@ -1,0 +1,8 @@
+-D
+nisse.source.jgit.dynamicVersion=true
+-D
+nisse.source.jgit.appendBranchName=true
+-D
+nisse.source.jgit.appendSnapshot=false
+-D
+nisse.source.jgit.increasePatchVersion=false

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/invoker.properties
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2026 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals=-V validate 

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/pom.xml
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2026 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-dynamic-versioning-branchname-master</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>it-dynamic-versioning-branchname-master</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/selector.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/selector.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+try {
+    // smoke test if we have a needed tools
+    def gitVersion = "git --version".execute()
+    gitVersion.consumeProcessOutput(System.out, System.out)
+    gitVersion.waitFor()
+    return gitVersion.exitValue() == 0
+} catch (Exception e) {
+    // some error occurs - we skip a test
+    return false
+}

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+void exec(String command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git init')
+exec('git config user.email "you@example.com"')
+exec('git config user.name "Your Name"')
+
+exec('git add test.txt')
+exec('git commit -m initial-commit')
+exec('git tag 1.0.0')
+exec('git tag')
+
+testFile << 'content2'
+exec('git add test.txt')
+exec('git commit -m commit_no2')
+
+testFile << 'content3'
+exec('git add test.txt')
+exec('git commit -m commit_no3')
+
+testFile << 'content4'
+exec('git add test.txt')
+exec('git commit -m commit_no4')

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
@@ -11,11 +11,18 @@ void exec(String command) {
     proc.waitFor()
     assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
 }
+void execIgnoreExitCode(String command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+}
 
 def testFile = new File(basedir, 'test.txt')
 testFile << 'content'
 
 exec('git init')
+// this below is just to ensure same outcome; branch may be already master
+execIgnoreExitCode('git branch -m master')
 exec('git config user.email "you@example.com"')
 exec('git config user.name "Your Name"')
 

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/setup.groovy
@@ -11,18 +11,11 @@ void exec(String command) {
     proc.waitFor()
     assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
 }
-void execIgnoreExitCode(String command) {
-    def proc = command.execute(null, basedir)
-    proc.consumeProcessOutput(System.out, System.out)
-    proc.waitFor()
-}
 
 def testFile = new File(basedir, 'test.txt')
 testFile << 'content'
 
-exec('git init')
-// this below is just to ensure same outcome; branch may be already master
-execIgnoreExitCode('git branch -m master')
+exec('git init -b master')
 exec('git config user.email "you@example.com"')
 exec('git config user.name "Your Name"')
 

--- a/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/verify.groovy
+++ b/it/extension3-its/src/it/it-dynamic-versioning-branchname-master/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+// check that property was set
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+// Read the log file
+def logContent = mavenLogFile.text
+
+// Define a pattern to match the version output
+def versionPattern = /\$\{nisse.jgit.dynamicVersion\}=(.+)/
+def matcher = (logContent =~ versionPattern)
+assert matcher.find() : "Version information not found in log file"
+
+// Extract the version from the matched group
+def actualVersion = matcher[0][1]
+
+def expectedVersion = '1.0.0-3-master'
+
+assert actualVersion == expectedVersion : "Expected version '${expectedVersion}', but found '${actualVersion}'"

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -709,7 +709,7 @@ public class JGitPropertySource implements PropertySource {
                 }
                 count++;
             }
-            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), null);
+            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), head);
         } catch (GitAPIException e) {
             throw new Exception("Error reading Git information.", e);
         }
@@ -778,7 +778,7 @@ public class JGitPropertySource implements PropertySource {
 
     protected VersionInformation mayAddQualifier(
             NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head)
-            throws GitAPIException, IOException {
+            throws GitAPIException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -777,8 +777,7 @@ public class JGitPropertySource implements PropertySource {
     }
 
     protected VersionInformation mayAddQualifier(
-            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head)
-            throws GitAPIException {
+            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head) throws GitAPIException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -194,6 +194,13 @@ public class JGitPropertySource implements PropertySource {
     private static final String DEFAULT_APPEND_SNAPSHOT = Boolean.TRUE.toString();
 
     /**
+     * Whether the branch name shall be appended or not.
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCHNAME = "nisse.source.jgit.appendBranchName";
+
+    private static final String DEFAULT_APPEND_BRANCH_NAME = Boolean.FALSE.toString();
+
+    /**
      * Whether the DIRTY qualifier shall be appended or not.
      */
     private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_DIRTY = "nisse.source.jgit.appendDirty";
@@ -539,7 +546,7 @@ public class JGitPropertySource implements PropertySource {
 
                 if (isCustomPattern) {
                     // With custom pattern, version hints take priority (git history only contains matching tags)
-                    vi = mayAddQualifier(configuration, git, hintVersion);
+                    vi = mayAddQualifier(configuration, git, hintVersion, head);
                     logger.debug("Using version hint (custom pattern): {}", versionHint.get());
                 } else {
                     // With default pattern, compare versions
@@ -550,7 +557,7 @@ public class JGitPropertySource implements PropertySource {
 
                     if (isDefaultGitVersion) {
                         // No regular release tags found, use version hint directly
-                        vi = mayAddQualifier(configuration, git, hintVersion);
+                        vi = mayAddQualifier(configuration, git, hintVersion, head);
                         logger.debug("Using version hint (no regular release tags found): {}", versionHint.get());
                     } else {
                         // Compare versions - use hint only if it's higher than git history version
@@ -559,7 +566,7 @@ public class JGitPropertySource implements PropertySource {
 
                         if (hintVersionParsed.compareTo(gitHistoryVersionParsed) > 0) {
                             // Version hint is higher, use it
-                            vi = mayAddQualifier(configuration, git, hintVersion);
+                            vi = mayAddQualifier(configuration, git, hintVersion, head);
                             logger.debug("Using version hint (higher than git history): {}", versionHint.get());
                         } else {
                             // Git history version is higher or equal, use it
@@ -694,12 +701,12 @@ public class JGitPropertySource implements PropertySource {
                         if (appendBuildNumber) {
                             vi.setBuildNumber(count);
                         }
-                        return mayAddQualifier(configuration, git, vi);
+                        return mayAddQualifier(configuration, git, vi, head);
                     }
                 }
                 count++;
             }
-            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count));
+            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), null);
         } catch (GitAPIException e) {
             throw new Exception("Error reading Git information.", e);
         }
@@ -766,8 +773,9 @@ public class JGitPropertySource implements PropertySource {
         }
     }
 
-    protected VersionInformation mayAddQualifier(NisseConfiguration configuration, Git git, VersionInformation vi)
-            throws GitAPIException {
+    protected VersionInformation mayAddQualifier(
+            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head)
+            throws GitAPIException, IOException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()
@@ -779,6 +787,15 @@ public class JGitPropertySource implements PropertySource {
                         configuration
                                 .getConfiguration()
                                 .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_DIRTY_QUALIFIER, DEFAULT_DIRTY_QUALIFIER));
+            }
+        }
+        boolean appendBranchName = Boolean.parseBoolean(configuration
+                .getConfiguration()
+                .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCHNAME, DEFAULT_APPEND_BRANCH_NAME));
+        if (appendBranchName) {
+            Optional<String> localBranch = localBranch(git, head).map(r -> Repository.shortenRefName(r.getName()));
+            if (localBranch.isPresent()) {
+                qualifier = appendQualifier(qualifier, localBranch.get());
             }
         }
         boolean appendSnapshot = Boolean.parseBoolean(configuration

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -785,6 +785,10 @@ public class JGitPropertySource implements PropertySource {
             if (localBranch == null) {
                 throw new IllegalStateException("Branch name configured to be qualifier, but is absent");
             }
+            String sanitizedBranchName = sanitizeBranchName(localBranch);
+            if (sanitizedBranchName == null || sanitizedBranchName.trim().isEmpty()) {
+                throw new IllegalStateException("Branch name configured to be qualifier, but is empty");
+            }
             qualifier = appendQualifier(qualifier, sanitizeBranchName(localBranch));
         }
         boolean appendSnapshot = Boolean.parseBoolean(configuration

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -198,7 +198,7 @@ public class JGitPropertySource implements PropertySource {
     /**
      * Whether the branch name shall be appended or not.
      */
-    private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCHNAME = "nisse.source.jgit.appendBranchName";
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCH_NAME = "nisse.source.jgit.appendBranchName";
 
     private static final String DEFAULT_APPEND_BRANCH_NAME = Boolean.FALSE.toString();
 
@@ -381,7 +381,7 @@ public class JGitPropertySource implements PropertySource {
                     if (Boolean.parseBoolean(configuration
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION, DEFAULT_DYNAMIC_VERSION))) {
-                        result.put(JGIT_DYNAMIC_VERSION, resolveDynamicVersion(configuration, git, head));
+                        result.put(JGIT_DYNAMIC_VERSION, resolveDynamicVersion(result, configuration, git, head));
                     }
                     if (Boolean.parseBoolean(configuration
                             .getConfiguration()
@@ -517,11 +517,8 @@ public class JGitPropertySource implements PropertySource {
         }
     }
 
-    public String resolveDynamicVersion(NisseConfiguration configuration, Git git) throws Exception {
-        return resolveDynamicVersion(configuration, git, git.getRepository().resolve("HEAD"));
-    }
-
-    String resolveDynamicVersion(NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
+    String resolveDynamicVersion(
+            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
         VersionInformation vi;
 
         Optional<String> useVersion =
@@ -532,7 +529,7 @@ public class JGitPropertySource implements PropertySource {
             logger.debug("Using explicit version from useVersion property: {}", useVersion.get());
         } else {
             // First, get version from git history (regular release tags)
-            VersionInformation gitHistoryVersion = getVersionFromGit(configuration, git, head);
+            VersionInformation gitHistoryVersion = getVersionFromGit(properties, configuration, git, head);
             logger.debug("Version from git history: {}", gitHistoryVersion.toString());
 
             // Check if using custom version hint pattern
@@ -549,7 +546,7 @@ public class JGitPropertySource implements PropertySource {
 
                 if (isCustomPattern) {
                     // With custom pattern, version hints take priority (git history only contains matching tags)
-                    vi = mayAddQualifier(configuration, git, hintVersion, head);
+                    vi = mayAddQualifier(properties, configuration, git, hintVersion);
                     logger.debug("Using version hint (custom pattern): {}", versionHint.get());
                 } else {
                     // With default pattern, compare versions
@@ -560,7 +557,7 @@ public class JGitPropertySource implements PropertySource {
 
                     if (isDefaultGitVersion) {
                         // No regular release tags found, use version hint directly
-                        vi = mayAddQualifier(configuration, git, hintVersion, head);
+                        vi = mayAddQualifier(properties, configuration, git, hintVersion);
                         logger.debug("Using version hint (no regular release tags found): {}", versionHint.get());
                     } else {
                         // Compare versions - use hint only if it's higher than git history version
@@ -569,7 +566,7 @@ public class JGitPropertySource implements PropertySource {
 
                         if (hintVersionParsed.compareTo(gitHistoryVersionParsed) > 0) {
                             // Version hint is higher, use it
-                            vi = mayAddQualifier(configuration, git, hintVersion, head);
+                            vi = mayAddQualifier(properties, configuration, git, hintVersion);
                             logger.debug("Using version hint (higher than git history): {}", versionHint.get());
                         } else {
                             // Git history version is higher or equal, use it
@@ -667,12 +664,8 @@ public class JGitPropertySource implements PropertySource {
         return result;
     }
 
-    protected VersionInformation getVersionFromGit(NisseConfiguration configuration, Git git) throws Exception {
-        return getVersionFromGit(configuration, git, git.getRepository().resolve("HEAD"));
-    }
-
-    protected VersionInformation getVersionFromGit(NisseConfiguration configuration, Git git, ObjectId head)
-            throws Exception {
+    protected VersionInformation getVersionFromGit(
+            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
         try {
             RevCommit lastCommit = getLastCommit(git, head);
             logger.debug("last commit: {}", lastCommit.toString());
@@ -704,12 +697,13 @@ public class JGitPropertySource implements PropertySource {
                         if (appendBuildNumber) {
                             vi.setBuildNumber(count);
                         }
-                        return mayAddQualifier(configuration, git, vi, head);
+                        return mayAddQualifier(properties, configuration, git, vi);
                     }
                 }
                 count++;
             }
-            return mayAddQualifier(configuration, git, new VersionInformation(defaultVersion + "-" + count), head);
+            return mayAddQualifier(
+                    properties, configuration, git, new VersionInformation(defaultVersion + "-" + count));
         } catch (GitAPIException e) {
             throw new Exception("Error reading Git information.", e);
         }
@@ -777,13 +771,14 @@ public class JGitPropertySource implements PropertySource {
     }
 
     protected VersionInformation mayAddQualifier(
-            NisseConfiguration configuration, Git git, VersionInformation vi, ObjectId head) throws GitAPIException {
+            Map<String, String> properties, NisseConfiguration configuration, Git git, VersionInformation vi)
+            throws GitAPIException {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()
                 .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_DIRTY, DEFAULT_APPEND_DIRTY));
         if (appendDirty) {
-            if (!isClean(git)) {
+            if (!Boolean.parseBoolean(properties.get(JGIT_CLEAN))) {
                 qualifier = appendQualifier(
                         qualifier,
                         configuration
@@ -793,12 +788,13 @@ public class JGitPropertySource implements PropertySource {
         }
         boolean appendBranchName = Boolean.parseBoolean(configuration
                 .getConfiguration()
-                .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCHNAME, DEFAULT_APPEND_BRANCH_NAME));
+                .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BRANCH_NAME, DEFAULT_APPEND_BRANCH_NAME));
         if (appendBranchName) {
-            Optional<String> localBranch = localBranch(git, head).map(r -> Repository.shortenRefName(r.getName()));
-            if (localBranch.isPresent()) {
-                qualifier = appendQualifier(qualifier, localBranch.get());
+            String localBranch = properties.get(JGIT_BRANCH_NAME);
+            if (localBranch == null) {
+                throw new IllegalStateException("Branch name configured to be qualifier, but is absent");
             }
+            qualifier = appendQualifier(qualifier, sanitizeBranchName(localBranch));
         }
         boolean appendSnapshot = Boolean.parseBoolean(configuration
                 .getConfiguration()
@@ -938,5 +934,23 @@ public class JGitPropertySource implements PropertySource {
         Pattern hintTagPattern = Pattern.compile("refs/tags/v?" + regexPattern);
 
         return hintTagPattern.matcher(tagName).matches();
+    }
+
+    private static final Pattern UNSAFE_CHARS = Pattern.compile("[^A-Za-z0-9._-]");
+
+    /**
+     * Turns a branch name into a path fragment that is safe on all platforms.
+     */
+    static String sanitizeBranchName(String branchName) {
+        List<String> segments = new ArrayList<>();
+        for (String segment : branchName.split("/")) {
+            String cleaned = UNSAFE_CHARS.matcher(segment).replaceAll("-");
+            segments.add(cleaned);
+        }
+        String result = String.join("-", segments);
+        while (result.endsWith("-")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
     }
 }

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -373,7 +373,7 @@ public class JGitPropertySource implements PropertySource {
                         }
                     }
 
-                    Optional<Ref> localBranch = localBranch(repository, head);
+                    Optional<Ref> localBranch = localBranch(repository, worktreeGitDir, head);
                     localBranch
                             .map(r -> Repository.shortenRefName(r.getName()))
                             .ifPresent(branchName -> result.put(JGIT_BRANCH_NAME, branchName));
@@ -426,6 +426,29 @@ public class JGitPropertySource implements PropertySource {
         return repository.resolve("HEAD");
     }
 
+    /**
+     * Resolves the HEAD ref. In a worktree, HEAD is stored in the worktree-specific git
+     * directory rather than the common directory, so this method reads it from the correct location.
+     *
+     * @param repository the repository (opened against the common dir)
+     * @param worktreeGitDir the worktree-specific git directory, or {@code null} for normal repos
+     */
+    private Ref resolveHeadRef(Repository repository, Path worktreeGitDir) throws IOException {
+        if (worktreeGitDir != null) {
+            Path headFile = worktreeGitDir.resolve("HEAD");
+            String headContent = new String(Files.readAllBytes(headFile), StandardCharsets.UTF_8).trim();
+            if (headContent.startsWith("ref: ")) {
+                String refName = headContent.substring(5);
+                return repository.exactRef(refName);
+                // Worktree HEAD points to a branch that doesn't exist yet
+            } else {
+                return null;
+            }
+        }
+
+        return repository.exactRef("HEAD");
+    }
+
     private RevCommit getLastCommit(Git git, ObjectId head) throws GitAPIException, IOException {
         if (head != null) {
             return git.log().add(head).setMaxCount(1).call().iterator().next();
@@ -438,21 +461,31 @@ public class JGitPropertySource implements PropertySource {
         return git.status().call().isClean();
     }
 
-    private Optional<Ref> localBranch(Repository repository, ObjectId head) throws GitAPIException, IOException {
-        if (head == null) {
-            return Optional.empty();
-        }
-        Set<Ref> refs = repository.getRefDatabase().getTipsWithSha1(head);
-        for (Ref r : refs) {
-            if (r.isSymbolic()) {
-                return Optional.of(r.getTarget());
+    private Optional<Ref> localBranch(Repository repository, Path worktreeGitDir, ObjectId head) throws IOException {
+        if (worktreeGitDir != null) {
+            Ref wtHead = resolveHeadRef(repository, worktreeGitDir);
+            if (wtHead != null) {
+                if (wtHead.isSymbolic()) {
+                    return Optional.of(wtHead.getTarget());
+                }
+                if (!"HEAD".equals(wtHead.getName())) {
+                    return Optional.of(wtHead);
+                }
             }
         }
-        if (refs.size() == 1) {
-            Ref ref = refs.iterator().next();
-            // if "detached" return empty
-            if (!"HEAD".equals(ref.getName())) {
-                return Optional.of(ref);
+        if (head != null) {
+            Set<Ref> refs = repository.getRefDatabase().getTipsWithSha1(head);
+            for (Ref r : refs) {
+                if (r.isSymbolic()) {
+                    return Optional.of(r.getTarget());
+                }
+            }
+            if (refs.size() == 1) {
+                Ref ref = refs.iterator().next();
+                // if "detached" return empty
+                if (!"HEAD".equals(ref.getName())) {
+                    return Optional.of(ref);
+                }
             }
         }
         return Optional.empty();

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -394,7 +394,7 @@ public class JGitPropertySource implements PropertySource {
             logger.debug("Seems this is not a git checkout; ignoring property source {}", NAME, e);
         } catch (Exception e) {
             logger.error("Exception in JGitPropertySource: {}", e.toString());
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
         return Collections.unmodifiableMap(result);
     }
@@ -518,7 +518,8 @@ public class JGitPropertySource implements PropertySource {
     }
 
     String resolveDynamicVersion(
-            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
+            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head)
+            throws GitAPIException, IOException {
         VersionInformation vi;
 
         Optional<String> useVersion =
@@ -546,7 +547,7 @@ public class JGitPropertySource implements PropertySource {
 
                 if (isCustomPattern) {
                     // With custom pattern, version hints take priority (git history only contains matching tags)
-                    vi = mayAddQualifier(properties, configuration, git, hintVersion);
+                    vi = mayAddQualifier(properties, configuration, hintVersion);
                     logger.debug("Using version hint (custom pattern): {}", versionHint.get());
                 } else {
                     // With default pattern, compare versions
@@ -557,7 +558,7 @@ public class JGitPropertySource implements PropertySource {
 
                     if (isDefaultGitVersion) {
                         // No regular release tags found, use version hint directly
-                        vi = mayAddQualifier(properties, configuration, git, hintVersion);
+                        vi = mayAddQualifier(properties, configuration, hintVersion);
                         logger.debug("Using version hint (no regular release tags found): {}", versionHint.get());
                     } else {
                         // Compare versions - use hint only if it's higher than git history version
@@ -566,7 +567,7 @@ public class JGitPropertySource implements PropertySource {
 
                         if (hintVersionParsed.compareTo(gitHistoryVersionParsed) > 0) {
                             // Version hint is higher, use it
-                            vi = mayAddQualifier(properties, configuration, git, hintVersion);
+                            vi = mayAddQualifier(properties, configuration, hintVersion);
                             logger.debug("Using version hint (higher than git history): {}", versionHint.get());
                         } else {
                             // Git history version is higher or equal, use it
@@ -595,7 +596,8 @@ public class JGitPropertySource implements PropertySource {
      * gradle-git-versioner algorithm: each commit either bumps a version component (and resets
      * lower components and the commit count) or increments the commit count.
      */
-    String resolveCountingVersion(NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
+    String resolveCountingVersion(NisseConfiguration configuration, Git git, ObjectId head)
+            throws GitAPIException, IOException {
         Map<String, String> config = configuration.getConfiguration();
 
         int major = Integer.parseInt(config.getOrDefault(JGIT_CONF_COUNTING_START_MAJOR, DEFAULT_COUNTING_START_MAJOR));
@@ -608,40 +610,36 @@ public class JGitPropertySource implements PropertySource {
 
         int commitCount = 0;
 
-        try {
-            Iterable<RevCommit> commits =
-                    head != null ? git.log().add(head).call() : git.log().call();
-            List<RevCommit> all = new ArrayList<>();
-            for (RevCommit c : commits) {
-                all.add(c);
-            }
-            Collections.reverse(all);
-
-            for (RevCommit c : all) {
-                String message = c.getFullMessage();
-                if (message.contains(matchMajor)) {
-                    major++;
-                    minor = 0;
-                    patch = 0;
-                    commitCount = 0;
-                } else if (message.contains(matchMinor)) {
-                    minor++;
-                    patch = 0;
-                    commitCount = 0;
-                } else if (message.contains(matchPatch)) {
-                    patch++;
-                    commitCount = 0;
-                } else {
-                    commitCount++;
-                }
-            }
-
-            String version = formatCountingVersion(pattern, major, minor, patch, commitCount);
-            logger.debug("counting version resolved to: {}", version);
-            return version;
-        } catch (GitAPIException e) {
-            throw new Exception("Error reading Git information.", e);
+        Iterable<RevCommit> commits =
+                head != null ? git.log().add(head).call() : git.log().call();
+        List<RevCommit> all = new ArrayList<>();
+        for (RevCommit c : commits) {
+            all.add(c);
         }
+        Collections.reverse(all);
+
+        for (RevCommit c : all) {
+            String message = c.getFullMessage();
+            if (message.contains(matchMajor)) {
+                major++;
+                minor = 0;
+                patch = 0;
+                commitCount = 0;
+            } else if (message.contains(matchMinor)) {
+                minor++;
+                patch = 0;
+                commitCount = 0;
+            } else if (message.contains(matchPatch)) {
+                patch++;
+                commitCount = 0;
+            } else {
+                commitCount++;
+            }
+        }
+
+        String version = formatCountingVersion(pattern, major, minor, patch, commitCount);
+        logger.debug("counting version resolved to: {}", version);
+        return version;
     }
 
     /**
@@ -665,48 +663,42 @@ public class JGitPropertySource implements PropertySource {
     }
 
     protected VersionInformation getVersionFromGit(
-            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head) throws Exception {
-        try {
-            RevCommit lastCommit = getLastCommit(git, head);
-            logger.debug("last commit: {}", lastCommit.toString());
+            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head)
+            throws GitAPIException, IOException {
+        RevCommit lastCommit = getLastCommit(git, head);
+        logger.debug("last commit: {}", lastCommit.toString());
 
-            Iterable<RevCommit> commits =
-                    head != null ? git.log().add(head).call() : git.log().call();
-            int count = 0;
-            for (RevCommit commit : commits) {
-                Optional<VersionInformation> ovi = getHighestVersionTagForCommit(configuration, git, commit);
+        Iterable<RevCommit> commits =
+                head != null ? git.log().add(head).call() : git.log().call();
+        int count = 0;
+        for (RevCommit commit : commits) {
+            Optional<VersionInformation> ovi = getHighestVersionTagForCommit(configuration, git, commit);
 
-                if (ovi.isPresent()) {
-                    VersionInformation vi = ovi.get();
+            if (ovi.isPresent()) {
+                VersionInformation vi = ovi.get();
 
-                    if (commit.equals(lastCommit)) {
-                        return vi;
-                    } else {
-                        boolean increasePatchVersion = Boolean.parseBoolean(configuration
-                                .getConfiguration()
-                                .getOrDefault(
-                                        JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION,
-                                        DEFAULT_INCREASE_PATCH_VERSION));
-                        if (increasePatchVersion) {
-                            vi.setPatch(vi.getPatch() + 1);
-                        }
-                        boolean appendBuildNumber = Boolean.parseBoolean(configuration
-                                .getConfiguration()
-                                .getOrDefault(
-                                        JGIT_CONF_SYSTEM_PROPERTY_APPEND_BUILD_NUMBER, DEFAULT_APPEND_BUILD_NUMBER));
-                        if (appendBuildNumber) {
-                            vi.setBuildNumber(count);
-                        }
-                        return mayAddQualifier(properties, configuration, git, vi);
+                if (commit.equals(lastCommit)) {
+                    return vi;
+                } else {
+                    boolean increasePatchVersion = Boolean.parseBoolean(configuration
+                            .getConfiguration()
+                            .getOrDefault(
+                                    JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION, DEFAULT_INCREASE_PATCH_VERSION));
+                    if (increasePatchVersion) {
+                        vi.setPatch(vi.getPatch() + 1);
                     }
+                    boolean appendBuildNumber = Boolean.parseBoolean(configuration
+                            .getConfiguration()
+                            .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BUILD_NUMBER, DEFAULT_APPEND_BUILD_NUMBER));
+                    if (appendBuildNumber) {
+                        vi.setBuildNumber(count);
+                    }
+                    return mayAddQualifier(properties, configuration, vi);
                 }
-                count++;
             }
-            return mayAddQualifier(
-                    properties, configuration, git, new VersionInformation(defaultVersion + "-" + count));
-        } catch (GitAPIException e) {
-            throw new Exception("Error reading Git information.", e);
+            count++;
         }
+        return mayAddQualifier(properties, configuration, new VersionInformation(defaultVersion + "-" + count));
     }
 
     private Optional<VersionInformation> getHighestVersionTagForCommit(
@@ -766,13 +758,12 @@ public class JGitPropertySource implements PropertySource {
         try {
             return versionScheme.parseVersion(string);
         } catch (InvalidVersionSpecificationException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
     }
 
     protected VersionInformation mayAddQualifier(
-            Map<String, String> properties, NisseConfiguration configuration, Git git, VersionInformation vi)
-            throws GitAPIException {
+            Map<String, String> properties, NisseConfiguration configuration, VersionInformation vi) {
         String qualifier = null;
         boolean appendDirty = Boolean.parseBoolean(configuration
                 .getConfiguration()
@@ -828,22 +819,18 @@ public class JGitPropertySource implements PropertySource {
      * @param configuration The Nisse configuration
      * @param git The git repository
      * @return Optional version string extracted from hint tags
-     * @throws Exception if git operations fail
+     * @throws GitAPIException if git operations fail
      */
     protected Optional<String> findVersionHint(NisseConfiguration configuration, Git git, ObjectId head)
-            throws Exception {
-        try {
-            String hintPattern = configuration
-                    .getConfiguration()
-                    .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_VERSION_HINT_PATTERN, DEFAULT_VERSION_HINT_PATTERN);
+            throws GitAPIException {
+        String hintPattern = configuration
+                .getConfiguration()
+                .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_VERSION_HINT_PATTERN, DEFAULT_VERSION_HINT_PATTERN);
 
-            List<String> hintVersions = findVersionHintTags(git, hintPattern, head);
-            logger.debug("Found version hint tags: {}", hintVersions);
+        List<String> hintVersions = findVersionHintTags(git, hintPattern, head);
+        logger.debug("Found version hint tags: {}", hintVersions);
 
-            return findHighestVersionFromHints(hintVersions);
-        } catch (GitAPIException e) {
-            throw new Exception("Error reading version hint tags from Git.", e);
-        }
+        return findHighestVersionFromHints(hintVersions);
     }
 
     /**

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -40,7 +41,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ConfigConstants;
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -373,7 +373,7 @@ public class JGitPropertySource implements PropertySource {
                         }
                     }
 
-                    Optional<Ref> localBranch = localBranch(git, head);
+                    Optional<Ref> localBranch = localBranch(repository, head);
                     localBranch
                             .map(r -> Repository.shortenRefName(r.getName()))
                             .ifPresent(branchName -> result.put(JGIT_BRANCH_NAME, branchName));
@@ -438,13 +438,24 @@ public class JGitPropertySource implements PropertySource {
         return git.status().call().isClean();
     }
 
-    private Optional<Ref> localBranch(Git git, ObjectId head) throws GitAPIException {
+    private Optional<Ref> localBranch(Repository repository, ObjectId head) throws GitAPIException, IOException {
         if (head == null) {
             return Optional.empty();
         }
-        return git.branchList().call().stream()
-                .filter(ref -> head.equals(ref.getObjectId()) && !Constants.HEAD.equals(ref.getName()))
-                .findFirst();
+        Set<Ref> refs = repository.getRefDatabase().getTipsWithSha1(head);
+        for (Ref r : refs) {
+            if (r.isSymbolic()) {
+                return Optional.of(r.getTarget());
+            }
+        }
+        if (refs.size() == 1) {
+            Ref ref = refs.iterator().next();
+            // if "detached" return empty
+            if (!"HEAD".equals(ref.getName())) {
+                return Optional.of(ref);
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -786,6 +786,15 @@ public class JGitPropertySourceTest {
         assertEquals("1.2.3", JGitPropertySource.formatCountingVersion("%M.%m.%p", 1, 2, 3, 5));
     }
 
+    @Test
+    void sanitizeBranchName() {
+        assertEquals("master", JGitPropertySource.sanitizeBranchName("master"));
+        assertEquals("feat-cool-feature-01", JGitPropertySource.sanitizeBranchName("feat/cool-feature-01"));
+        assertEquals(
+                "is-this-valid-branch-name-at-all",
+                JGitPropertySource.sanitizeBranchName("is this valid branch name at all?"));
+    }
+
     private static void assertCountingVersion(
             String expected, JGitPropertySource source, Path repo, Map<String, String> userProps) throws Exception {
         Map<String, String> properties = source.getProperties(SimpleNisseConfiguration.builder()

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -535,6 +535,35 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testBranchNameTwoBranchesSameCommit(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init", "-b", "master");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file1.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file1.txt");
+        exec(mainRepo, "git", "commit", "-m", "file1 commit");
+        Files.write(mainRepo.resolve("file2.txt"), "hello again".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file2.txt");
+        exec(mainRepo, "git", "commit", "-m", "file2 commit");
+
+        // create two branch; but both point to same commit
+        exec(mainRepo, "git", "checkout", "-b", "dev1");
+        exec(mainRepo, "git", "checkout", "-b", "dev2");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertTrue(properties.containsKey("branchName"));
+        assertEquals("dev2", properties.get("branchName"));
+    }
+
+    @Test
     void testVersionHintReachability(@TempDir Path tempDir) throws Exception {
         Path repo = tempDir.resolve("repo");
         Files.createDirectories(repo);

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -564,6 +564,59 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testBranchNameTwoWorktreesSameCommit(@TempDir Path tempDir) throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        exec(mainRepo, "git", "init", "-b", "master");
+        exec(mainRepo, "git", "config", "user.email", "test@test.com");
+        exec(mainRepo, "git", "config", "user.name", "Test");
+        Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        exec(mainRepo, "git", "add", "file.txt");
+        exec(mainRepo, "git", "commit", "-m", "initial commit");
+        exec(mainRepo, "git", "tag", "v1.0.0");
+
+        // Create a worktrees without additional commit
+        Path worktree1 = tempDir.resolve("worktree1");
+        exec(mainRepo, "git", "worktree", "add", worktree1.toString());
+        Path worktree2 = tempDir.resolve("worktree2");
+        exec(mainRepo, "git", "worktree", "add", worktree2.toString());
+
+        String mainCommit = execOutput(mainRepo, "git", "rev-parse", "HEAD").trim();
+        String worktree1Commit =
+                execOutput(worktree1, "git", "rev-parse", "HEAD").trim();
+        String worktree2Commit =
+                execOutput(worktree2, "git", "rev-parse", "HEAD").trim();
+        assertEquals(mainCommit, worktree1Commit, "Worktree should have a different HEAD");
+        assertEquals(mainCommit, worktree2Commit, "Worktree should have a different HEAD");
+
+        Map<String, String> properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(worktree1)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertEquals("worktree1", properties.get("branchName"));
+
+        properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(worktree2)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertEquals("worktree2", properties.get("branchName"));
+
+        // check main repo
+        properties = new JGitPropertySource()
+                .getProperties(SimpleNisseConfiguration.builder()
+                        .withCurrentWorkingDirectory(mainRepo)
+                        .build());
+
+        assertFalse(properties.isEmpty(), "Properties should not be empty");
+        assertEquals("master", properties.get("branchName"));
+    }
+
+    @Test
     void testVersionHintReachability(@TempDir Path tempDir) throws Exception {
         Path repo = tempDir.resolve("repo");
         Files.createDirectories(repo);


### PR DESCRIPTION
Fixes #188 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to append the current Git branch name to dynamically generated versions when no tag is available.
  * Branch names are converted into safe, readable version qualifiers.
  * The option is disabled by default and can be enabled through Maven configuration.

* **Documentation**
  * Documented the new branch-name configuration option and its default behavior.

* **Tests**
  * Added coverage for branch-name formatting and dynamic version generation on master and development branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->