### PR TITLE
feat: Derive dynamic version increment from Conventional Commits

### DIFF
--- a/GIT_CONFIGURATION.md
+++ b/GIT_CONFIGURATION.md
@@ -95,6 +95,31 @@ If current commit doesn't have a tag, should the patch version be incremented or
 versions over and over again (the last found tag). Moreover, disabling this feature, but keeping
 `nisse.source.jgit.appendSnapshot` enabled, will produce "backward", hence broken Maven versions!
 
+#### `nisse.source.jgit.conventionalCommits`
+
+**Default:** `false`
+
+Set to `true` to derive the version increase from
+[Conventional Commits](https://www.conventionalcommits.org/) in the commits made since the last version tag,
+instead of always increasing the patch version.
+
+The highest increase among those commits wins:
+
+| Commit | Increase | `1.2.3` becomes |
+| --- | --- | --- |
+| `fix: ...`, `chore: ...`, or any other type | patch | `1.2.4` |
+| `feat: ...` | minor, patch reset | `1.3.0` |
+| `feat!: ...`, `fix(api)!: ...`, or a `BREAKING CHANGE:` footer | major, minor and patch reset | `2.0.0` |
+
+A commit that is not a Conventional Commit contributes a patch increase, so enabling this can never produce a
+*smaller* increase than `nisse.source.jgit.increasePatchVersion` would have.
+
+When enabled, this **supersedes** `nisse.source.jgit.increasePatchVersion`, which is then not consulted.
+
+Note this differs from `nisse.source.jgit.countingVersion`: that walks the *entire* history from a starting
+version and counts directives such as `[minor]`, whereas this reads Conventional Commit types and applies a
+single increase to the *last version tag*.
+
 #### `nisse.source.jgit.appendBuildNumber`
 
 **Default:** `true`

--- a/GIT_CONFIGURATION.md
+++ b/GIT_CONFIGURATION.md
@@ -100,21 +100,50 @@ versions over and over again (the last found tag). Moreover, disabling this feat
 **Default:** `false`
 
 Set to `true` to derive the version increase from
-[Conventional Commits](https://www.conventionalcommits.org/) in the commits made since the last version tag,
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) made since the last version tag,
 instead of always increasing the patch version.
+
+Only meaningful together with `nisse.source.jgit.dynamicVersion`; it has no effect on its own, and none when
+the repository has no version tag to increase from (the `0.1.0-{commitCount}` fallback stands whatever the
+commits say).
 
 The highest increase among those commits wins:
 
 | Commit | Increase | `1.2.3` becomes |
 | --- | --- | --- |
-| `fix: ...`, `chore: ...`, or any other type | patch | `1.2.4` |
-| `feat: ...` | minor, patch reset | `1.3.0` |
+| `fix: ...`, `chore(deps): ...`, or any other type | patch | `1.2.4` |
+| `feat: ...`, `feat(lang): ...` | minor, patch reset | `1.3.0` |
 | `feat!: ...`, `fix(api)!: ...`, or a `BREAKING CHANGE:` footer | major, minor and patch reset | `2.0.0` |
 
-A commit that is not a Conventional Commit contributes a patch increase, so enabling this can never produce a
-*smaller* increase than `nisse.source.jgit.increasePatchVersion` would have.
+Those are the version numbers alone. With the defaults (`appendBuildNumber`, `appendSnapshot`) the property
+value is `1.3.0-2-SNAPSHOT` rather than `1.3.0`.
+
+What counts, precisely:
+
+- **The commit range is `tag..HEAD` by reachability**, not by date — so a branch cut before the release and
+  merged after it still counts, and the tagged commit itself never does.
+- **A `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer counts only in the trailer block** — the last paragraph —
+  and only on a commit that is a Conventional Commit to begin with. The same words in body prose, in a quoted
+  changelog, or in the body `git revert` copies do not increase the major.
+- **A commit that is not a Conventional Commit contributes a patch increase.** Enabling this can therefore
+  never produce a *smaller* increase than `nisse.source.jgit.increasePatchVersion` would have.
+- **The type is matched case-insensitively** (`Feat:` is a `feat`); the footer token is not, per the
+  specification. The scope must be non-empty, and the colon must be followed by a space.
+- **A prerelease qualifier is dropped by a minor or major increase**: `1.2.3-rc1` with a `feat!:` becomes
+  `2.0.0`, not `2.0.0-rc1`. A patch increase keeps it, as before.
+- **A revert does not undo an increase.** The reverted commit is still in the range, so its increase stands.
 
 When enabled, this **supersedes** `nisse.source.jgit.increasePatchVersion`, which is then not consulted.
+
+!!! note
+
+    Enabling this makes every commit author a participant in the release-version decision, since the increase
+    is read from their commit messages. Consider that against your contribution model before enabling it on a
+    repository that merges pull requests from forks.
+
+Interaction with version hint tags: the hint is used only when it is *higher* than the version derived from
+git history. A single `feat!:` can make the derived version outrank a hint that was pinning the intended next
+release.
 
 Note this differs from `nisse.source.jgit.countingVersion`: that walks the *entire* history from a starting
 version and counts directives such as `[minor]`, whereas this reads Conventional Commit types and applies a

--- a/GIT_CONFIGURATION.md
+++ b/GIT_CONFIGURATION.md
@@ -95,19 +95,26 @@ If current commit doesn't have a tag, should the patch version be incremented or
 versions over and over again (the last found tag). Moreover, disabling this feature, but keeping
 `nisse.source.jgit.appendSnapshot` enabled, will produce "backward", hence broken Maven versions!
 
-#### `nisse.source.jgit.conventionalCommits`
+#### `nisse.source.jgit.versionIncrement`
 
-**Default:** `false`
+**Default:** `patch`
 
-Set to `true` to derive the version increase from
-[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) made since the last version tag,
-instead of always increasing the patch version.
+Controls how the version is increased when the current commit is not tagged. Legal values:
 
-Only meaningful together with `nisse.source.jgit.dynamicVersion`; it has no effect on its own, and none when
-the repository has no version tag to increase from (the `0.1.0-{commitCount}` fallback stands whatever the
-commits say).
+| Value | Behaviour | Equivalent deprecated property |
+| --- | --- | --- |
+| `patch` (default) | Always increase the patch version | `increasePatchVersion=true` |
+| `none` | No increase | `increasePatchVersion=false` |
+| `conventionalCommits` | Derive from [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) | `conventionalCommits=true` |
 
-The highest increase among those commits wins:
+When this property is set it takes precedence over the deprecated `nisse.source.jgit.increasePatchVersion`
+and `nisse.source.jgit.conventionalCommits` booleans, which are still honoured as fallbacks when
+`versionIncrement` is absent.
+
+##### Conventional Commits mode
+
+When `versionIncrement=conventionalCommits`, the increase comes from the commits made since the last version
+tag. The highest increase among those commits wins:
 
 | Commit | Increase | `1.2.3` becomes |
 | --- | --- | --- |
@@ -125,15 +132,13 @@ What counts, precisely:
 - **A `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer counts only in the trailer block** — the last paragraph —
   and only on a commit that is a Conventional Commit to begin with. The same words in body prose, in a quoted
   changelog, or in the body `git revert` copies do not increase the major.
-- **A commit that is not a Conventional Commit contributes a patch increase.** Enabling this can therefore
-  never produce a *smaller* increase than `nisse.source.jgit.increasePatchVersion` would have.
+- **A commit that is not a Conventional Commit contributes a patch increase.** This mode can therefore
+  never produce a *smaller* increase than `versionIncrement=patch` would have.
 - **The type is matched case-insensitively** (`Feat:` is a `feat`); the footer token is not, per the
   specification. The scope must be non-empty, and the colon must be followed by a space.
 - **A prerelease qualifier is dropped by a minor or major increase**: `1.2.3-rc1` with a `feat!:` becomes
   `2.0.0`, not `2.0.0-rc1`. A patch increase keeps it, as before.
 - **A revert does not undo an increase.** The reverted commit is still in the range, so its increase stands.
-
-When enabled, this **supersedes** `nisse.source.jgit.increasePatchVersion`, which is then not consulted.
 
 !!! note
 
@@ -148,6 +153,19 @@ release.
 Note this differs from `nisse.source.jgit.countingVersion`: that walks the *entire* history from a starting
 version and counts directives such as `[minor]`, whereas this reads Conventional Commit types and applies a
 single increase to the *last version tag*.
+
+#### `nisse.source.jgit.versionIncrement.zeroMajorDemotion`
+
+**Default:** `false`
+
+When `true` and the current major version is `0`, a breaking-change increment is demoted from major to minor,
+keeping the project in the `0.x` space. For example, `feat!:` on `0.5.2` produces `0.6.0` instead of `1.0.0`.
+
+This follows the convention used by npm, Cargo, and `semantic-release` where pre-1.0 projects signal instability
+via the `0.x` major and reserve the jump to `1.0.0` for an explicit decision by the maintainer.
+
+Only meaningful together with `versionIncrement=conventionalCommits`. Has no effect in other modes, since only
+Conventional Commits mode can produce major or minor bumps.
 
 #### `nisse.source.jgit.appendBuildNumber`
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -124,8 +124,10 @@ nisseConfig {
 
         // --- dynamic version (tag-based) ---
         dynamicVersion = true                // default: false
-        increasePatchVersion = true          // default: true
-        conventionalCommits = false          // default: false
+        versionIncrement = "patch"           // default: "patch" ("patch", "none", "conventionalCommits")
+        zeroMajorDemotion = false            // default: false (demote MAJOR to MINOR on 0.x)
+        increasePatchVersion = true          // deprecated, use versionIncrement
+        conventionalCommits = false          // deprecated, use versionIncrement
         appendBuildNumber = true             // default: true
         appendSnapshot = true                // default: true
         appendDirty = false                  // default: false
@@ -167,15 +169,19 @@ v1.2.3  →  on tag: 1.2.3
          not on tag: 1.2.4-5-SNAPSHOT  (5 commits after tag)
 ```
 
-Control the output with `appendSnapshot`, `appendBuildNumber`, `increasePatchVersion`,
+Control the output with `appendSnapshot`, `appendBuildNumber`, `versionIncrement`,
 `appendDirty`, and `dirtyQualifier`.
 
-Set `conventionalCommits = true` to take the increase from
+Set `versionIncrement = "conventionalCommits"` to take the increase from
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) in the range `tag..HEAD` instead
 of always increasing the patch: `feat:` increases the minor, `feat!:` or a `BREAKING CHANGE:` footer in
 the trailer block increases the major, anything else increases the patch. The highest wins, lower
-components reset, and a prerelease qualifier is dropped by a minor or major increase. It supersedes
-`increasePatchVersion` when enabled. See `GIT_CONFIGURATION.md` for the full rules.
+components reset, and a prerelease qualifier is dropped by a minor or major increase. Set
+`versionIncrement = "none"` to disable incrementing entirely. See `GIT_CONFIGURATION.md` for the full rules.
+
+Set `zeroMajorDemotion = true` to demote a major bump to minor on `0.x` versions, keeping the project in
+the `0.x` space until the maintainer explicitly decides to go `1.0.0`. Only meaningful with
+`versionIncrement = "conventionalCommits"`.
 
 ## Counting Version
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -125,6 +125,7 @@ nisseConfig {
         // --- dynamic version (tag-based) ---
         dynamicVersion = true                // default: false
         increasePatchVersion = true          // default: true
+        conventionalCommits = false          // default: false
         appendBuildNumber = true             // default: true
         appendSnapshot = true                // default: true
         appendDirty = false                  // default: false
@@ -168,6 +169,11 @@ v1.2.3  →  on tag: 1.2.3
 
 Control the output with `appendSnapshot`, `appendBuildNumber`, `increasePatchVersion`,
 `appendDirty`, and `dirtyQualifier`.
+
+Set `conventionalCommits = true` to take the increase from
+[Conventional Commits](https://www.conventionalcommits.org/) since the last tag instead of always
+increasing the patch: `feat:` increases the minor, `feat!:` or a `BREAKING CHANGE:` footer increases
+the major, anything else increases the patch. It supersedes `increasePatchVersion` when enabled.
 
 ## Counting Version
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -171,9 +171,11 @@ Control the output with `appendSnapshot`, `appendBuildNumber`, `increasePatchVer
 `appendDirty`, and `dirtyQualifier`.
 
 Set `conventionalCommits = true` to take the increase from
-[Conventional Commits](https://www.conventionalcommits.org/) since the last tag instead of always
-increasing the patch: `feat:` increases the minor, `feat!:` or a `BREAKING CHANGE:` footer increases
-the major, anything else increases the patch. It supersedes `increasePatchVersion` when enabled.
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) in the range `tag..HEAD` instead
+of always increasing the patch: `feat:` increases the minor, `feat!:` or a `BREAKING CHANGE:` footer in
+the trailer block increases the major, anything else increases the patch. The highest wins, lower
+components reset, and a prerelease qualifier is dropped by a minor or major increase. It supersedes
+`increasePatchVersion` when enabled. See `GIT_CONFIGURATION.md` for the full rules.
 
 ## Counting Version
 

--- a/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseExtension.java
+++ b/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseExtension.java
@@ -103,6 +103,9 @@ public abstract class NisseExtension {
         /** Whether to increase the patch version. */
         public abstract Property<Boolean> getIncreasePatchVersion();
 
+        /** Whether to derive the version increase from Conventional Commits since the last version tag. */
+        public abstract Property<Boolean> getConventionalCommits();
+
         /** Whether to append the build number. */
         public abstract Property<Boolean> getAppendBuildNumber();
 
@@ -154,6 +157,7 @@ public abstract class NisseExtension {
             setIfPresent(props, "nisse.source.jgit.countingVersion", getCountingVersion());
             setIfPresent(props, "nisse.source.jgit.shortCommitIdLength", getShortCommitIdLength());
             setIfPresent(props, "nisse.source.jgit.increasePatchVersion", getIncreasePatchVersion());
+            setIfPresent(props, "nisse.source.jgit.conventionalCommits", getConventionalCommits());
             setIfPresent(props, "nisse.source.jgit.appendBuildNumber", getAppendBuildNumber());
             setIfPresent(props, "nisse.source.jgit.appendSnapshot", getAppendSnapshot());
             setIfPresent(props, "nisse.source.jgit.appendDirty", getAppendDirty());

--- a/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseExtension.java
+++ b/gradle/src/main/java/eu/maveniverse/gradle/nisse/plugin/NisseExtension.java
@@ -100,11 +100,30 @@ public abstract class NisseExtension {
         /** Length of the short commit id. */
         public abstract Property<Integer> getShortCommitIdLength();
 
-        /** Whether to increase the patch version. */
+        /**
+         * Whether to increase the patch version.
+         * @deprecated Use {@link #getVersionIncrement()} with value {@code "patch"} or {@code "none"} instead.
+         */
         public abstract Property<Boolean> getIncreasePatchVersion();
 
-        /** Whether to derive the version increase from Conventional Commits since the last version tag. */
+        /**
+         * Whether to derive the version increase from Conventional Commits since the last version tag.
+         * @deprecated Use {@link #getVersionIncrement()} with value {@code "conventionalCommits"} instead.
+         */
         public abstract Property<Boolean> getConventionalCommits();
+
+        /**
+         * Version increment strategy: {@code "patch"} (default), {@code "none"}, or {@code "conventionalCommits"}.
+         * Takes precedence over the deprecated {@link #getIncreasePatchVersion()} and
+         * {@link #getConventionalCommits()} properties.
+         */
+        public abstract Property<String> getVersionIncrement();
+
+        /**
+         * Whether to demote a MAJOR bump to MINOR on 0.x versions when using {@code conventionalCommits}.
+         * Defaults to {@code false}.
+         */
+        public abstract Property<Boolean> getZeroMajorDemotion();
 
         /** Whether to append the build number. */
         public abstract Property<Boolean> getAppendBuildNumber();
@@ -158,6 +177,8 @@ public abstract class NisseExtension {
             setIfPresent(props, "nisse.source.jgit.shortCommitIdLength", getShortCommitIdLength());
             setIfPresent(props, "nisse.source.jgit.increasePatchVersion", getIncreasePatchVersion());
             setIfPresent(props, "nisse.source.jgit.conventionalCommits", getConventionalCommits());
+            setIfPresent(props, "nisse.source.jgit.versionIncrement", getVersionIncrement());
+            setIfPresent(props, "nisse.source.jgit.versionIncrement.zeroMajorDemotion", getZeroMajorDemotion());
             setIfPresent(props, "nisse.source.jgit.appendBuildNumber", getAppendBuildNumber());
             setIfPresent(props, "nisse.source.jgit.appendSnapshot", getAppendSnapshot());
             setIfPresent(props, "nisse.source.jgit.appendDirty", getAppendDirty());

--- a/it/extension3-its/src/it/nisse-properties-fallback-empty/verify.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-empty/verify.groovy
@@ -6,19 +6,22 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-// Verify nisse's current behavior with empty values in .mvn/nisse.properties:
-// an empty string is not an unexpanded placeholder, so it IS loaded as-is.
-// (See maveniverse/nisse#194 for future empty-version-guard discussion.)
+// Verify that empty values in .mvn/nisse.properties are skipped with a warning
+// after the empty-value guard added in #194.
 
 def mavenLogFile = new File(basedir, 'build.log')
 assert mavenLogFile.exists() : "Maven log file does not exist"
 
 def logContent = mavenLogFile.text
 
-// Empty value should be loaded (not rejected) — nisse treats it as a valid
-// (albeit empty) property value.  The dump line ends with '=' and no value.
-assert logContent.contains('nisse.jgit.dynamicVersion=') :
-    "Empty fallback property nisse.jgit.dynamicVersion should have been loaded"
+// The empty-value guard (Fix #194) skips blank fallback properties and logs
+// a warning.  The property must NOT appear in the nisse dump output.
+assert !logContent.contains('nisse.jgit.dynamicVersion=') :
+    "Empty fallback property nisse.jgit.dynamicVersion should have been skipped"
+
+// A warning should be logged about the skipped empty property
+assert logContent.contains('Skipping empty fallback property') :
+    "Expected a warning about skipping the empty fallback property"
 
 // The build must succeed (POM uses a hardcoded version, not the empty property)
 assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension4-its/src/it/nisse-properties-fallback-empty/verify.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-empty/verify.groovy
@@ -6,19 +6,22 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-// Verify nisse's current behavior with empty values in .mvn/nisse.properties:
-// an empty string is not an unexpanded placeholder, so it IS loaded as-is.
-// (See maveniverse/nisse#194 for future empty-version-guard discussion.)
+// Verify that empty values in .mvn/nisse.properties are skipped with a warning
+// after the empty-value guard added in #194.
 
 def mavenLogFile = new File(basedir, 'build.log')
 assert mavenLogFile.exists() : "Maven log file does not exist"
 
 def logContent = mavenLogFile.text
 
-// Empty value should be loaded (not rejected) — nisse treats it as a valid
-// (albeit empty) property value.  The dump line ends with '=' and no value.
-assert logContent.contains('nisse.jgit.dynamicVersion=') :
-    "Empty fallback property nisse.jgit.dynamicVersion should have been loaded"
+// The empty-value guard (Fix #194) skips blank fallback properties and logs
+// a warning.  The property must NOT appear in the nisse dump output.
+assert !logContent.contains('nisse.jgit.dynamicVersion=') :
+    "Empty fallback property nisse.jgit.dynamicVersion should have been skipped"
+
+// A warning should be logged about the skipped empty property
+assert logContent.contains('Skipping empty fallback property') :
+    "Expected a warning about skipping the empty fallback property"
 
 // The build must succeed (POM uses a hardcoded version, not the empty property)
 assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -19,6 +19,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -182,6 +183,24 @@ public class JGitPropertySource implements PropertySource {
     private static final String DEFAULT_INCREASE_PATCH_VERSION = Boolean.TRUE.toString();
 
     /**
+     * Set to {@code true} to derive the version increment from
+     * <a href="https://www.conventionalcommits.org/">Conventional Commits</a> in the commits made since the last
+     * version tag, instead of always increasing the patch version.
+     * <p>
+     * The highest increment wins: a breaking change increases the major version (resetting minor and patch), a
+     * {@code feat} increases the minor version (resetting patch), and anything else increases the patch version.
+     * A commit that is not a Conventional Commit contributes a patch increment, so enabling this can never
+     * produce a <em>smaller</em> increment than {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION} would.
+     * <p>
+     * When enabled this <strong>supersedes</strong> {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION},
+     * which is then not consulted.
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS =
+            "nisse.source.jgit.conventionalCommits";
+
+    private static final String DEFAULT_CONVENTIONAL_COMMITS = Boolean.FALSE.toString();
+
+    /**
      * Whether the buildNumber shall be appended or not.
      */
     private static final String JGIT_CONF_SYSTEM_PROPERTY_APPEND_BUILD_NUMBER = "nisse.source.jgit.appendBuildNumber";
@@ -252,6 +271,18 @@ public class JGitPropertySource implements PropertySource {
      * Pattern for standard semantic versions, with an optional {@code "v"} prefix.
      */
     protected static final Pattern TAG_VERSION_PATTERN = Pattern.compile("refs/tags/v?((\\d+\\.\\d+\\.\\d+)(.*))");
+
+    /**
+     * A Conventional Commits subject line: {@code type(optional scope)!: description}, where {@code !} marks a
+     * breaking change.
+     */
+    private static final Pattern CONVENTIONAL_COMMIT_SUBJECT =
+            Pattern.compile("^(?<type>[a-zA-Z]+)(\\([^)]*\\))?(?<breaking>!)?:\\s");
+
+    /**
+     * The Conventional Commits breaking change footer. The specification allows both spellings.
+     */
+    private static final Pattern BREAKING_CHANGE_FOOTER = Pattern.compile("^BREAKING[ -]CHANGE:\\s", Pattern.MULTILINE);
 
     /**
      * Matches the credential-bearing userinfo (user, or user:password) in an HTTP(S) remote URL,
@@ -715,6 +746,7 @@ public class JGitPropertySource implements PropertySource {
         Iterable<RevCommit> commits =
                 head != null ? git.log().add(head).call() : git.log().call();
         int count = 0;
+        List<String> messagesSinceTag = new ArrayList<>();
         for (RevCommit commit : commits) {
             Optional<VersionInformation> ovi = getHighestVersionTagForCommit(configuration, git, commit);
 
@@ -724,12 +756,21 @@ public class JGitPropertySource implements PropertySource {
                 if (commit.equals(lastCommit)) {
                     return vi;
                 } else {
-                    boolean increasePatchVersion = Boolean.parseBoolean(configuration
+                    boolean conventionalCommits = Boolean.parseBoolean(configuration
                             .getConfiguration()
                             .getOrDefault(
-                                    JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION, DEFAULT_INCREASE_PATCH_VERSION));
-                    if (increasePatchVersion) {
-                        vi.setPatch(vi.getPatch() + 1);
+                                    JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS, DEFAULT_CONVENTIONAL_COMMITS));
+                    if (conventionalCommits) {
+                        increaseVersion(vi, bumpFrom(messagesSinceTag));
+                    } else {
+                        boolean increasePatchVersion = Boolean.parseBoolean(configuration
+                                .getConfiguration()
+                                .getOrDefault(
+                                        JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION,
+                                        DEFAULT_INCREASE_PATCH_VERSION));
+                        if (increasePatchVersion) {
+                            vi.setPatch(vi.getPatch() + 1);
+                        }
                     }
                     boolean appendBuildNumber = Boolean.parseBoolean(configuration
                             .getConfiguration()
@@ -740,9 +781,81 @@ public class JGitPropertySource implements PropertySource {
                     return mayAddQualifier(properties, configuration, vi);
                 }
             }
+            messagesSinceTag.add(commit.getFullMessage());
             count++;
         }
         return mayAddQualifier(properties, configuration, new VersionInformation(defaultVersion + "-" + count));
+    }
+
+    /**
+     * The version component a set of commits calls for, ordered so that the highest wins.
+     */
+    enum Bump {
+        PATCH,
+        MINOR,
+        MAJOR
+    }
+
+    /**
+     * The highest increment called for by the given full commit messages, per Conventional Commits.
+     * <p>
+     * A message that is not a Conventional Commit still contributes {@link Bump#PATCH}: this mode replaces the
+     * unconditional patch increment, so it must never increment less than that did.
+     */
+    static Bump bumpFrom(Collection<String> fullMessages) {
+        Bump highest = Bump.PATCH;
+        for (String message : fullMessages) {
+            Bump bump = bumpFrom(message);
+            if (bump.compareTo(highest) > 0) {
+                highest = bump;
+            }
+            if (highest == Bump.MAJOR) {
+                return highest;
+            }
+        }
+        return highest;
+    }
+
+    /**
+     * The increment called for by a single full commit message (subject and body).
+     */
+    static Bump bumpFrom(String fullMessage) {
+        if (fullMessage == null || fullMessage.isEmpty()) {
+            return Bump.PATCH;
+        }
+        if (BREAKING_CHANGE_FOOTER.matcher(fullMessage).find()) {
+            return Bump.MAJOR;
+        }
+        String subject = fullMessage.split("\\R", 2)[0];
+        Matcher matcher = CONVENTIONAL_COMMIT_SUBJECT.matcher(subject);
+        if (!matcher.find()) {
+            return Bump.PATCH;
+        }
+        if (matcher.group("breaking") != null) {
+            return Bump.MAJOR;
+        }
+        return "feat".equalsIgnoreCase(matcher.group("type")) ? Bump.MINOR : Bump.PATCH;
+    }
+
+    /**
+     * Applies an increment, resetting the components below it as semantic versioning requires.
+     */
+    static void increaseVersion(VersionInformation vi, Bump bump) {
+        switch (bump) {
+            case MAJOR:
+                vi.setMajor(vi.getMajor() + 1);
+                vi.setMinor(0);
+                vi.setPatch(0);
+                break;
+            case MINOR:
+                vi.setMinor(vi.getMinor() + 1);
+                vi.setPatch(0);
+                break;
+            case PATCH:
+            default:
+                vi.setPatch(vi.getPatch() + 1);
+                break;
+        }
     }
 
     private Optional<VersionInformation> getHighestVersionTagForCommit(

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -307,7 +307,7 @@ public class JGitPropertySource implements PropertySource {
      * breaking change.
      */
     private static final Pattern CONVENTIONAL_COMMIT_SUBJECT =
-            Pattern.compile("(?<type>[a-zA-Z]+)(\\([^)]+\\))?(?<breaking>!)?:\\s");
+            Pattern.compile("(?<type>[a-zA-Z]+)(\\([^)]+\\))?(?<breaking>!)?: ");
 
     /**
      * The Conventional Commits breaking change footer. The specification allows both spellings.
@@ -652,8 +652,9 @@ public class JGitPropertySource implements PropertySource {
             vi = new VersionInformation(useVersion.get());
             logger.debug("Using explicit version from useVersion property: {}", useVersion.get());
         } else {
-            // First, get version from git history (regular release tags)
-            GitVersion gitVersion = resolveVersionFromGit(properties, configuration, git, head);
+            // First, get version from git history (regular release tags).
+            // Routed through the protected hook so subclasses can override version resolution.
+            GitVersion gitVersion = getVersionFromGit(properties, configuration, git, head);
             VersionInformation gitHistoryVersion = gitVersion.getVersion();
             logger.debug("Version from git history: {}", gitHistoryVersion.toString());
 
@@ -785,16 +786,19 @@ public class JGitPropertySource implements PropertySource {
         return result;
     }
 
-    protected VersionInformation getVersionFromGit(
+    /**
+     * Resolves the version from git history, reporting both the version and whether it came from a release tag.
+     * <p>
+     * This is the primary extension hook for subclasses that need to customise version resolution.
+     * Override this method instead of manipulating {@link #resolveDynamicVersion} directly.
+     */
+    protected GitVersion getVersionFromGit(
             Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head)
             throws GitAPIException, IOException {
-        return resolveVersionFromGit(properties, configuration, git, head).getVersion();
+        return resolveVersionFromGit(properties, configuration, git, head);
     }
 
-    /**
-     * As {@link #getVersionFromGit}, but also reporting whether a release tag was found at all.
-     */
-    protected GitVersion resolveVersionFromGit(
+    private GitVersion resolveVersionFromGit(
             Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head)
             throws GitAPIException, IOException {
         RevCommit lastCommit = getLastCommit(git, head);
@@ -827,7 +831,7 @@ public class JGitPropertySource implements PropertySource {
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BUILD_NUMBER, DEFAULT_APPEND_BUILD_NUMBER));
                     if (appendBuildNumber) {
-                        vi.setBuildNumber(count);
+                        vi.setBuildNumber(commitCountSince(git, head, commit));
                     }
                     return new GitVersion(mayAddQualifier(properties, configuration, vi), true);
                 }
@@ -866,7 +870,19 @@ public class JGitPropertySource implements PropertySource {
     private String resolveVersionIncrement(Map<String, String> config) {
         String explicit = config.get(JGIT_CONF_SYSTEM_PROPERTY_VERSION_INCREMENT);
         if (explicit != null) {
-            return explicit.toLowerCase(Locale.ROOT);
+            String normalized = explicit.trim().toLowerCase(Locale.ROOT);
+            if (normalized.isEmpty()) {
+                logger.warn("Empty versionIncrement value, falling back to '{}'", VERSION_INCREMENT_PATCH);
+                return VERSION_INCREMENT_PATCH;
+            }
+            if (!VERSION_INCREMENT_PATCH.equals(normalized)
+                    && !VERSION_INCREMENT_NONE.equals(normalized)
+                    && !VERSION_INCREMENT_CONVENTIONAL_COMMITS.equals(normalized)) {
+                logger.warn(
+                        "Unknown versionIncrement value '{}', falling back to '{}'", explicit, VERSION_INCREMENT_PATCH);
+                return VERSION_INCREMENT_PATCH;
+            }
+            return normalized;
         }
         // Deprecated fallback: honour old booleans when the new property is absent
         if (Boolean.parseBoolean(
@@ -896,6 +912,19 @@ public class JGitPropertySource implements PropertySource {
             messages.add(commit.getFullMessage());
         }
         return messages;
+    }
+
+    /**
+     * The number of commits reachable from {@code head} but not from {@code tagged}: the count form of
+     * {@link #messagesSince(Git, ObjectId, RevCommit)}.
+     */
+    private int commitCountSince(Git git, ObjectId head, RevCommit tagged) throws GitAPIException, IOException {
+        ObjectId until = head != null ? head : git.getRepository().resolve(Constants.HEAD);
+        int count = 0;
+        for (RevCommit ignored : git.log().add(until).not(tagged.getId()).call()) {
+            count++;
+        }
+        return count;
     }
 
     /**

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -42,6 +42,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -183,17 +184,9 @@ public class JGitPropertySource implements PropertySource {
     private static final String DEFAULT_INCREASE_PATCH_VERSION = Boolean.TRUE.toString();
 
     /**
-     * Set to {@code true} to derive the version increment from
-     * <a href="https://www.conventionalcommits.org/">Conventional Commits</a> in the commits made since the last
-     * version tag, instead of always increasing the patch version.
-     * <p>
-     * The highest increment wins: a breaking change increases the major version (resetting minor and patch), a
-     * {@code feat} increases the minor version (resetting patch), and anything else increases the patch version.
-     * A commit that is not a Conventional Commit contributes a patch increment, so enabling this can never
-     * produce a <em>smaller</em> increment than {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION} would.
-     * <p>
-     * When enabled this <strong>supersedes</strong> {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION},
-     * which is then not consulted.
+     * Set to {@code true} to derive the version increase from Conventional Commits made since the last version
+     * tag, instead of always increasing the patch version. Supersedes
+     * {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION}. See {@code GIT_CONFIGURATION.md}.
      */
     private static final String JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS =
             "nisse.source.jgit.conventionalCommits";
@@ -277,12 +270,13 @@ public class JGitPropertySource implements PropertySource {
      * breaking change.
      */
     private static final Pattern CONVENTIONAL_COMMIT_SUBJECT =
-            Pattern.compile("^(?<type>[a-zA-Z]+)(\\([^)]*\\))?(?<breaking>!)?:\\s");
+            Pattern.compile("(?<type>[a-zA-Z]+)(\\([^)]+\\))?(?<breaking>!)?:\\s");
 
     /**
      * The Conventional Commits breaking change footer. The specification allows both spellings.
      */
-    private static final Pattern BREAKING_CHANGE_FOOTER = Pattern.compile("^BREAKING[ -]CHANGE:\\s", Pattern.MULTILINE);
+    private static final Pattern BREAKING_CHANGE_FOOTER =
+            Pattern.compile("^BREAKING[ -]CHANGE: \\S", Pattern.MULTILINE);
 
     /**
      * Matches the credential-bearing userinfo (user, or user:password) in an HTTP(S) remote URL,
@@ -605,7 +599,8 @@ public class JGitPropertySource implements PropertySource {
             logger.debug("Using explicit version from useVersion property: {}", useVersion.get());
         } else {
             // First, get version from git history (regular release tags)
-            VersionInformation gitHistoryVersion = getVersionFromGit(properties, configuration, git, head);
+            GitVersion gitVersion = resolveVersionFromGit(properties, configuration, git, head);
+            VersionInformation gitHistoryVersion = gitVersion.getVersion();
             logger.debug("Version from git history: {}", gitHistoryVersion.toString());
 
             // Check if using custom version hint pattern
@@ -626,10 +621,9 @@ public class JGitPropertySource implements PropertySource {
                     logger.debug("Using version hint (custom pattern): {}", versionHint.get());
                 } else {
                     // With default pattern, compare versions
-                    // Check if git history version is the default (meaning no regular release tags found)
-                    boolean isDefaultGitVersion = gitHistoryVersion.getMajor() == 0
-                            && gitHistoryVersion.getMinor() == 1
-                            && gitHistoryVersion.getPatch() == 0;
+                    // Whether a regular release tag was found at all. Reported by the walk rather than
+                    // inferred from the value: 0.1.0 is also what increasing a 0.0.x tag's minor produces.
+                    boolean isDefaultGitVersion = !gitVersion.isFromReleaseTag();
 
                     if (isDefaultGitVersion) {
                         // No regular release tags found, use version hint directly
@@ -740,13 +734,21 @@ public class JGitPropertySource implements PropertySource {
     protected VersionInformation getVersionFromGit(
             Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head)
             throws GitAPIException, IOException {
+        return resolveVersionFromGit(properties, configuration, git, head).getVersion();
+    }
+
+    /**
+     * As {@link #getVersionFromGit}, but also reporting whether a release tag was found at all.
+     */
+    protected GitVersion resolveVersionFromGit(
+            Map<String, String> properties, NisseConfiguration configuration, Git git, ObjectId head)
+            throws GitAPIException, IOException {
         RevCommit lastCommit = getLastCommit(git, head);
         logger.debug("last commit: {}", lastCommit.toString());
 
         Iterable<RevCommit> commits =
                 head != null ? git.log().add(head).call() : git.log().call();
         int count = 0;
-        List<String> messagesSinceTag = new ArrayList<>();
         for (RevCommit commit : commits) {
             Optional<VersionInformation> ovi = getHighestVersionTagForCommit(configuration, git, commit);
 
@@ -754,14 +756,14 @@ public class JGitPropertySource implements PropertySource {
                 VersionInformation vi = ovi.get();
 
                 if (commit.equals(lastCommit)) {
-                    return vi;
+                    return new GitVersion(vi, true);
                 } else {
                     boolean conventionalCommits = Boolean.parseBoolean(configuration
                             .getConfiguration()
                             .getOrDefault(
                                     JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS, DEFAULT_CONVENTIONAL_COMMITS));
                     if (conventionalCommits) {
-                        increaseVersion(vi, bumpFrom(messagesSinceTag));
+                        increaseVersion(vi, highestBumpFrom(messagesSince(git, head, commit)));
                     } else {
                         boolean increasePatchVersion = Boolean.parseBoolean(configuration
                                 .getConfiguration()
@@ -778,13 +780,56 @@ public class JGitPropertySource implements PropertySource {
                     if (appendBuildNumber) {
                         vi.setBuildNumber(count);
                     }
-                    return mayAddQualifier(properties, configuration, vi);
+                    return new GitVersion(mayAddQualifier(properties, configuration, vi), true);
                 }
             }
-            messagesSinceTag.add(commit.getFullMessage());
             count++;
         }
-        return mayAddQualifier(properties, configuration, new VersionInformation(defaultVersion + "-" + count));
+        return new GitVersion(
+                mayAddQualifier(properties, configuration, new VersionInformation(defaultVersion + "-" + count)),
+                false);
+    }
+
+    /**
+     * The full messages of the commits reachable from {@code head} but not from {@code tagged}: the range
+     * {@code tagged..head}.
+     *
+     * <p>Asking git for the range explicitly matters. The walk that finds the tag is ordered by commit date, so a
+     * branch cut before the tag and merged after it is reached only <em>after</em> the tagged commit, and would
+     * otherwise be missed. Reachability, not date, is what "since the last release" means. The tagged commit
+     * itself is excluded by construction.
+     */
+    private List<String> messagesSince(Git git, ObjectId head, RevCommit tagged) throws GitAPIException, IOException {
+        ObjectId until = head != null ? head : git.getRepository().resolve(Constants.HEAD);
+        List<String> messages = new ArrayList<>();
+        for (RevCommit commit : git.log().add(until).not(tagged.getId()).call()) {
+            messages.add(commit.getFullMessage());
+        }
+        return messages;
+    }
+
+    /**
+     * A version resolved from git history, and whether it came from a release tag at all. That cannot be
+     * recognised from the value: {@link #defaultVersion} is also what increasing a {@code 0.0.x} tag's minor
+     * produces.
+     */
+    protected static final class GitVersion {
+        private final VersionInformation version;
+
+        private final boolean fromReleaseTag;
+
+        GitVersion(VersionInformation version, boolean fromReleaseTag) {
+            this.version = version;
+            this.fromReleaseTag = fromReleaseTag;
+        }
+
+        public VersionInformation getVersion() {
+            return version;
+        }
+
+        public boolean isFromReleaseTag() {
+            return fromReleaseTag;
+        }
     }
 
     /**
@@ -797,12 +842,12 @@ public class JGitPropertySource implements PropertySource {
     }
 
     /**
-     * The highest increment called for by the given full commit messages, per Conventional Commits.
+     * The highest increase called for by the given full commit messages, per Conventional Commits.
      * <p>
      * A message that is not a Conventional Commit still contributes {@link Bump#PATCH}: this mode replaces the
      * unconditional patch increment, so it must never increment less than that did.
      */
-    static Bump bumpFrom(Collection<String> fullMessages) {
+    static Bump highestBumpFrom(Collection<String> fullMessages) {
         Bump highest = Bump.PATCH;
         for (String message : fullMessages) {
             Bump bump = bumpFrom(message);
@@ -823,38 +868,48 @@ public class JGitPropertySource implements PropertySource {
         if (fullMessage == null || fullMessage.isEmpty()) {
             return Bump.PATCH;
         }
-        if (BREAKING_CHANGE_FOOTER.matcher(fullMessage).find()) {
-            return Bump.MAJOR;
-        }
-        String subject = fullMessage.split("\\R", 2)[0];
+        int newline = fullMessage.indexOf('\n');
+        String subject = newline < 0 ? fullMessage : fullMessage.substring(0, newline);
         Matcher matcher = CONVENTIONAL_COMMIT_SUBJECT.matcher(subject);
-        if (!matcher.find()) {
+        if (!matcher.lookingAt()) {
+            // Not a Conventional Commit, so it has no footers either. A BREAKING CHANGE line in the body of an
+            // ordinary commit is prose: a quoted changelog, or the body git revert copies verbatim.
             return Bump.PATCH;
         }
-        if (matcher.group("breaking") != null) {
+        if (matcher.group("breaking") != null || hasBreakingFooter(fullMessage)) {
             return Bump.MAJOR;
         }
         return "feat".equalsIgnoreCase(matcher.group("type")) ? Bump.MINOR : Bump.PATCH;
     }
 
     /**
+     * Whether the message's trailer block declares a breaking change. Only the last paragraph is searched, which
+     * is where the specification puts footers; the same words earlier in the body are prose.
+     */
+    private static boolean hasBreakingFooter(String fullMessage) {
+        int lastBlankLine = fullMessage.lastIndexOf("\n\n");
+        return lastBlankLine >= 0
+                && BREAKING_CHANGE_FOOTER
+                        .matcher(fullMessage.substring(lastBlankLine + 2))
+                        .find();
+    }
+
+    /**
      * Applies an increment, resetting the components below it as semantic versioning requires.
      */
     static void increaseVersion(VersionInformation vi, Bump bump) {
-        switch (bump) {
-            case MAJOR:
-                vi.setMajor(vi.getMajor() + 1);
-                vi.setMinor(0);
-                vi.setPatch(0);
-                break;
-            case MINOR:
-                vi.setMinor(vi.getMinor() + 1);
-                vi.setPatch(0);
-                break;
-            case PATCH:
-            default:
-                vi.setPatch(vi.getPatch() + 1);
-                break;
+        if (bump == Bump.MAJOR) {
+            vi.setMajor(vi.getMajor() + 1);
+            vi.setMinor(0);
+            vi.setPatch(0);
+            // 1.2.3-rc1 becoming 2.0.0-rc1 would claim to be a candidate for a release that never had one.
+            vi.setQualifier(null);
+        } else if (bump == Bump.MINOR) {
+            vi.setMinor(vi.getMinor() + 1);
+            vi.setPatch(0);
+            vi.setQualifier(null);
+        } else {
+            vi.setPatch(vi.getPatch() + 1);
         }
     }
 

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -187,11 +187,37 @@ public class JGitPropertySource implements PropertySource {
      * Set to {@code true} to derive the version increase from Conventional Commits made since the last version
      * tag, instead of always increasing the patch version. Supersedes
      * {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION}. See {@code GIT_CONFIGURATION.md}.
+     *
+     * @deprecated Use {@link #JGIT_CONF_SYSTEM_PROPERTY_VERSION_INCREMENT} with value {@code conventionalCommits}
+     *     instead. This property is still honoured as a fallback when {@code versionIncrement} is not set.
      */
     private static final String JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS =
             "nisse.source.jgit.conventionalCommits";
 
     private static final String DEFAULT_CONVENTIONAL_COMMITS = Boolean.FALSE.toString();
+
+    /**
+     * Version increment strategy. Legal values: {@code patch} (default, always increment patch),
+     * {@code none} (no increment), {@code conventionalCommits} (derive from Conventional Commits).
+     * <p>
+     * When set, this takes precedence over the deprecated {@link #JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION}
+     * and {@link #JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS} properties.
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_VERSION_INCREMENT = "nisse.source.jgit.versionIncrement";
+
+    private static final String VERSION_INCREMENT_PATCH = "patch";
+    private static final String VERSION_INCREMENT_NONE = "none";
+    private static final String VERSION_INCREMENT_CONVENTIONAL_COMMITS = "conventionalcommits";
+
+    /**
+     * When {@code true} and the current major version is 0, a {@link Bump#MAJOR} increment is demoted to
+     * {@link Bump#MINOR}, keeping the project in the {@code 0.x} space. Only meaningful together with
+     * {@code versionIncrement=conventionalCommits}.
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_ZERO_MAJOR_DEMOTION =
+            "nisse.source.jgit.versionIncrement.zeroMajorDemotion";
+
+    private static final String DEFAULT_ZERO_MAJOR_DEMOTION = Boolean.FALSE.toString();
 
     /**
      * Whether the buildNumber shall be appended or not.
@@ -758,22 +784,17 @@ public class JGitPropertySource implements PropertySource {
                 if (commit.equals(lastCommit)) {
                     return new GitVersion(vi, true);
                 } else {
-                    boolean conventionalCommits = Boolean.parseBoolean(configuration
-                            .getConfiguration()
-                            .getOrDefault(
-                                    JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS, DEFAULT_CONVENTIONAL_COMMITS));
-                    if (conventionalCommits) {
-                        increaseVersion(vi, highestBumpFrom(messagesSince(git, head, commit)));
-                    } else {
-                        boolean increasePatchVersion = Boolean.parseBoolean(configuration
+                    String increment = resolveVersionIncrement(configuration.getConfiguration());
+                    if (VERSION_INCREMENT_CONVENTIONAL_COMMITS.equals(increment)) {
+                        boolean zeroMajorDemotion = Boolean.parseBoolean(configuration
                                 .getConfiguration()
                                 .getOrDefault(
-                                        JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION,
-                                        DEFAULT_INCREASE_PATCH_VERSION));
-                        if (increasePatchVersion) {
-                            vi.setPatch(vi.getPatch() + 1);
-                        }
+                                        JGIT_CONF_SYSTEM_PROPERTY_ZERO_MAJOR_DEMOTION, DEFAULT_ZERO_MAJOR_DEMOTION));
+                        increaseVersion(vi, highestBumpFrom(messagesSince(git, head, commit)), zeroMajorDemotion);
+                    } else if (VERSION_INCREMENT_PATCH.equals(increment)) {
+                        vi.setPatch(vi.getPatch() + 1);
                     }
+                    // VERSION_INCREMENT_NONE: no change
                     boolean appendBuildNumber = Boolean.parseBoolean(configuration
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_APPEND_BUILD_NUMBER, DEFAULT_APPEND_BUILD_NUMBER));
@@ -788,6 +809,31 @@ public class JGitPropertySource implements PropertySource {
         return new GitVersion(
                 mayAddQualifier(properties, configuration, new VersionInformation(defaultVersion + "-" + count)),
                 false);
+    }
+
+    /**
+     * Resolves the effective version increment strategy from the configuration. The new
+     * {@code nisse.source.jgit.versionIncrement} property takes precedence; when absent, the deprecated
+     * booleans {@code conventionalCommits} and {@code increasePatchVersion} are used as fallbacks.
+     *
+     * @return one of {@link #VERSION_INCREMENT_PATCH}, {@link #VERSION_INCREMENT_NONE}, or
+     *     {@link #VERSION_INCREMENT_CONVENTIONAL_COMMITS}
+     */
+    private String resolveVersionIncrement(Map<String, String> config) {
+        String explicit = config.get(JGIT_CONF_SYSTEM_PROPERTY_VERSION_INCREMENT);
+        if (explicit != null) {
+            return explicit.toLowerCase(Locale.ROOT);
+        }
+        // Deprecated fallback: honour old booleans when the new property is absent
+        if (Boolean.parseBoolean(
+                config.getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_CONVENTIONAL_COMMITS, DEFAULT_CONVENTIONAL_COMMITS))) {
+            return VERSION_INCREMENT_CONVENTIONAL_COMMITS;
+        }
+        if (!Boolean.parseBoolean(config.getOrDefault(
+                JGIT_CONF_SYSTEM_PROPERTY_INCREASE_PATCH_VERSION, DEFAULT_INCREASE_PATCH_VERSION))) {
+            return VERSION_INCREMENT_NONE;
+        }
+        return VERSION_INCREMENT_PATCH;
     }
 
     /**
@@ -896,15 +942,22 @@ public class JGitPropertySource implements PropertySource {
 
     /**
      * Applies an increment, resetting the components below it as semantic versioning requires.
+     *
+     * @param zeroMajorDemotion when {@code true} and the current major is 0, a {@link Bump#MAJOR} is demoted to
+     *     {@link Bump#MINOR}, keeping the project in the {@code 0.x} space
      */
-    static void increaseVersion(VersionInformation vi, Bump bump) {
-        if (bump == Bump.MAJOR) {
+    static void increaseVersion(VersionInformation vi, Bump bump, boolean zeroMajorDemotion) {
+        Bump effective = bump;
+        if (zeroMajorDemotion && vi.getMajor() == 0 && effective == Bump.MAJOR) {
+            effective = Bump.MINOR;
+        }
+        if (effective == Bump.MAJOR) {
             vi.setMajor(vi.getMajor() + 1);
             vi.setMinor(0);
             vi.setPatch(0);
             // 1.2.3-rc1 becoming 2.0.0-rc1 would claim to be a candidate for a release that never had one.
             vi.setQualifier(null);
-        } else if (bump == Bump.MINOR) {
+        } else if (effective == Bump.MINOR) {
             vi.setMinor(vi.getMinor() + 1);
             vi.setPatch(0);
             vi.setQualifier(null);

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -900,16 +900,27 @@ public class JGitPropertySourceTest {
         // a type merely starting with "feat" is not "feat"
         assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("feature: not the feat type"));
 
-        // "BREAKING CHANGE" must be a footer, not prose
+        // "BREAKING CHANGE" counts only as a footer in the trailer block, never as prose
         assertEquals(
                 JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("fix: mentions BREAKING CHANGE: inline"));
+        assertEquals(
+                JGitPropertySource.Bump.PATCH,
+                JGitPropertySource.bumpFrom("fix: a bug\n\nBREAKING CHANGE: none, quoting a changelog\n\nreally"));
+        // an ordinary commit has no footers at all — this is the body git revert copies verbatim
+        assertEquals(
+                JGitPropertySource.Bump.PATCH,
+                JGitPropertySource.bumpFrom(
+                        "Revert \"feat: x\"\n\nThis reverts commit abc.\n\nBREAKING CHANGE: moved"));
+        // the specification requires a non-empty scope and a space after the colon
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("feat(): empty scope"));
 
         // the highest wins
         assertEquals(
                 JGitPropertySource.Bump.MAJOR,
-                JGitPropertySource.bumpFrom(Arrays.asList("fix: a", "feat: b", "feat!: c")));
-        assertEquals(JGitPropertySource.Bump.MINOR, JGitPropertySource.bumpFrom(Arrays.asList("fix: a", "feat: b")));
-        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom(Collections.emptyList()));
+                JGitPropertySource.highestBumpFrom(Arrays.asList("fix: a", "feat: b", "feat!: c")));
+        assertEquals(
+                JGitPropertySource.Bump.MINOR, JGitPropertySource.highestBumpFrom(Arrays.asList("fix: a", "feat: b")));
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.highestBumpFrom(Collections.emptyList()));
     }
 
     @Test
@@ -927,10 +938,12 @@ public class JGitPropertySourceTest {
         exec(repo, "git", "init", "-b", "master");
         exec(repo, "git", "config", "user.email", "test@test.com");
         exec(repo, "git", "config", "user.name", "Test");
+        exec(repo, "git", "config", "commit.gpgsign", "false");
 
         Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
         exec(repo, "git", "add", "file.txt");
-        exec(repo, "git", "commit", "-m", "initial");
+        // The tagged commit's own message is load-bearing: were it counted, this would major-bump.
+        exec(repo, "git", "commit", "-m", "feat!: the release commit itself");
         exec(repo, "git", "tag", "1.2.3");
 
         // on the tag itself: the tag is the version, untouched
@@ -967,15 +980,138 @@ public class JGitPropertySourceTest {
         exec(repo, "git", "init", "-b", "master");
         exec(repo, "git", "config", "user.email", "test@test.com");
         exec(repo, "git", "config", "user.name", "Test");
+        exec(repo, "git", "config", "commit.gpgsign", "false");
 
         Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
         exec(repo, "git", "add", "file.txt");
-        exec(repo, "git", "commit", "-m", "initial");
+        // The tagged commit's own message is load-bearing: were it counted, this would major-bump.
+        exec(repo, "git", "commit", "-m", "feat!: the release commit itself");
         exec(repo, "git", "tag", "1.2.3");
 
         // the default is unchanged: a breaking feature still only increases the patch version
         exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: a breaking feature");
         assertDynamicVersion("1.2.4", source, repo, userProps);
+    }
+
+    @Test
+    void testConventionalCommitsAcrossAMergeOfABranchCutBeforeTheTag(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+
+        // a branch cut BEFORE the release, carrying the feature
+        exec(repo, "git", "checkout", "-b", "side");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: side feature");
+
+        // the release happens on master afterwards, so the side commit is older than the tag
+        exec(repo, "git", "checkout", "master");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: release");
+        exec(repo, "git", "tag", "1.2.3");
+
+        // ...and only then is the branch merged
+        exec(repo, "git", "merge", "--no-ff", "-m", "chore: merge side", "side");
+
+        // The feature is in tag..HEAD, so it counts — even though its commit date precedes the tag.
+        assertDynamicVersion("1.3.0", source, repo, userProps);
+    }
+
+    @Test
+    void testConventionalCommitsSupersedesIncreasePatchVersion(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.increasePatchVersion", "false");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: a feature");
+
+        // increasePatchVersion=false would have pinned this to 1.2.3; conventionalCommits supersedes it
+        assertDynamicVersion("1.3.0", source, repo, userProps);
+    }
+
+    @Test
+    void testConventionalCommitsWithBuildNumberAndNoReleaseTag(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: a feature");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "docs: more");
+
+        // the build number rides along with a minor increase exactly as it does with a patch one
+        assertDynamicVersion("1.3.0-2", source, repo, userProps);
+
+        // with no release tag at all the fallback stands, whatever the commits say
+        Path untagged = newRepo(tempDir.resolve("untagged"));
+        exec(untagged, "git", "commit", "--allow-empty", "-m", "feat!: breaking, but nothing to increase from");
+        assertDynamicVersion("0.1.0-1", source, untagged, userProps);
+    }
+
+    @Test
+    void testConventionalCommitsDropsAQualifierItHasOutgrown(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3-rc1");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // 2.0.0-rc1 would claim to be a candidate for a release that never had one
+        assertDynamicVersion("2.0.0", source, repo, userProps);
+    }
+
+    @Test
+    void testConventionalCommitsMinorOnZeroZeroXIsNotMistakenForNoReleaseTag(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "0.0.5");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: a feature");
+
+        // A feat on a 0.0.x tag lands on exactly 0.1.0 — which is also the no-tag fallback value.
+        assertDynamicVersion("0.1.0", source, repo, userProps);
+
+        // A lower version hint must NOT win. It would if "no release tag found" were inferred from the value,
+        // and the build would go backwards from 0.1.0 to 0.0.6.
+        exec(repo, "git", "tag", "0.0.6-SNAPSHOT");
+        assertDynamicVersion("0.1.0", source, repo, userProps);
+    }
+
+    private static Path newRepo(Path dir) throws Exception {
+        Files.createDirectories(dir);
+        exec(dir, "git", "init", "-b", "master");
+        exec(dir, "git", "config", "user.email", "test@test.com");
+        exec(dir, "git", "config", "user.name", "Test");
+        // never inherit the developer's signing configuration
+        exec(dir, "git", "config", "commit.gpgsign", "false");
+        return dir;
     }
 
     private static void assertDynamicVersion(

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -875,6 +876,117 @@ public class JGitPropertySourceTest {
         assertEquals(
                 "is-this-valid-branch-name-at-all",
                 JGitPropertySource.sanitizeBranchName("is this valid branch name at all?"));
+    }
+
+    @Test
+    void testConventionalCommitsBumpFromMessages() {
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("fix: a bug"));
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("chore(deps): bump something"));
+        assertEquals(JGitPropertySource.Bump.MINOR, JGitPropertySource.bumpFrom("feat: a feature"));
+        assertEquals(JGitPropertySource.Bump.MINOR, JGitPropertySource.bumpFrom("feat(core): a scoped feature"));
+        assertEquals(JGitPropertySource.Bump.MAJOR, JGitPropertySource.bumpFrom("feat!: breaking"));
+        assertEquals(JGitPropertySource.Bump.MAJOR, JGitPropertySource.bumpFrom("fix(api)!: breaking"));
+        assertEquals(
+                JGitPropertySource.Bump.MAJOR,
+                JGitPropertySource.bumpFrom("feat: something\n\nBREAKING CHANGE: it moved"));
+        assertEquals(
+                JGitPropertySource.Bump.MAJOR,
+                JGitPropertySource.bumpFrom("feat: something\n\nBREAKING-CHANGE: it moved"));
+
+        // not Conventional Commits at all: still a patch, never less than increasePatchVersion gave
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("just a message"));
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom(""));
+
+        // a type merely starting with "feat" is not "feat"
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("feature: not the feat type"));
+
+        // "BREAKING CHANGE" must be a footer, not prose
+        assertEquals(
+                JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("fix: mentions BREAKING CHANGE: inline"));
+
+        // the highest wins
+        assertEquals(
+                JGitPropertySource.Bump.MAJOR,
+                JGitPropertySource.bumpFrom(Arrays.asList("fix: a", "feat: b", "feat!: c")));
+        assertEquals(JGitPropertySource.Bump.MINOR, JGitPropertySource.bumpFrom(Arrays.asList("fix: a", "feat: b")));
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom(Collections.emptyList()));
+    }
+
+    @Test
+    void testConventionalCommitsVersion(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+        exec(repo, "git", "tag", "1.2.3");
+
+        // on the tag itself: the tag is the version, untouched
+        assertDynamicVersion("1.2.3", source, repo, userProps);
+
+        // fix: -> patch
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+        assertDynamicVersion("1.2.4", source, repo, userProps);
+
+        // feat: outranks the fix -> minor, patch reset
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: a feature");
+        assertDynamicVersion("1.3.0", source, repo, userProps);
+
+        // a breaking change outranks both -> major, minor and patch reset
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: a breaking feature");
+        assertDynamicVersion("2.0.0", source, repo, userProps);
+
+        // a later ordinary commit does not lower the increment
+        exec(repo, "git", "commit", "--allow-empty", "-m", "docs: tidy up");
+        assertDynamicVersion("2.0.0", source, repo, userProps);
+    }
+
+    @Test
+    void testConventionalCommitsDisabledKeepsPatchBehaviour(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+        exec(repo, "git", "tag", "1.2.3");
+
+        // the default is unchanged: a breaking feature still only increases the patch version
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: a breaking feature");
+        assertDynamicVersion("1.2.4", source, repo, userProps);
+    }
+
+    private static void assertDynamicVersion(
+            String expected, JGitPropertySource source, Path repo, Map<String, String> userProps) throws Exception {
+        Map<String, String> properties = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+        String value = properties.get("dynamicVersion");
+        assertNotNull(value, "dynamicVersion should be set");
+        assertEquals(expected, value);
     }
 
     private static void assertCountingVersion(

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -927,7 +927,7 @@ public class JGitPropertySourceTest {
     void testConventionalCommitsVersion(@TempDir Path tempDir) throws Exception {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.dynamicVersion", "true");
-        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
         userProps.put("nisse.source.jgit.appendBuildNumber", "false");
         userProps.put("nisse.source.jgit.appendSnapshot", "false");
         JGitPropertySource source = new JGitPropertySource();
@@ -997,7 +997,7 @@ public class JGitPropertySourceTest {
     void testConventionalCommitsAcrossAMergeOfABranchCutBeforeTheTag(@TempDir Path tempDir) throws Exception {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.dynamicVersion", "true");
-        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
         userProps.put("nisse.source.jgit.appendBuildNumber", "false");
         userProps.put("nisse.source.jgit.appendSnapshot", "false");
         JGitPropertySource source = new JGitPropertySource();
@@ -1023,6 +1023,8 @@ public class JGitPropertySourceTest {
 
     @Test
     void testConventionalCommitsSupersedesIncreasePatchVersion(@TempDir Path tempDir) throws Exception {
+        // Uses the deprecated boolean fallback to verify backward compatibility:
+        // conventionalCommits=true takes precedence over increasePatchVersion=false
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.dynamicVersion", "true");
         userProps.put("nisse.source.jgit.conventionalCommits", "true");
@@ -1044,7 +1046,7 @@ public class JGitPropertySourceTest {
     void testConventionalCommitsWithBuildNumberAndNoReleaseTag(@TempDir Path tempDir) throws Exception {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.dynamicVersion", "true");
-        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
         userProps.put("nisse.source.jgit.appendSnapshot", "false");
         JGitPropertySource source = new JGitPropertySource();
 
@@ -1067,7 +1069,7 @@ public class JGitPropertySourceTest {
     void testConventionalCommitsDropsAQualifierItHasOutgrown(@TempDir Path tempDir) throws Exception {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.dynamicVersion", "true");
-        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
         userProps.put("nisse.source.jgit.appendBuildNumber", "false");
         userProps.put("nisse.source.jgit.appendSnapshot", "false");
         JGitPropertySource source = new JGitPropertySource();
@@ -1085,7 +1087,7 @@ public class JGitPropertySourceTest {
     void testConventionalCommitsMinorOnZeroZeroXIsNotMistakenForNoReleaseTag(@TempDir Path tempDir) throws Exception {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.dynamicVersion", "true");
-        userProps.put("nisse.source.jgit.conventionalCommits", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
         userProps.put("nisse.source.jgit.appendBuildNumber", "false");
         userProps.put("nisse.source.jgit.appendSnapshot", "false");
         JGitPropertySource source = new JGitPropertySource();
@@ -1102,6 +1104,152 @@ public class JGitPropertySourceTest {
         // and the build would go backwards from 0.1.0 to 0.0.6.
         exec(repo, "git", "tag", "0.0.6-SNAPSHOT");
         assertDynamicVersion("0.1.0", source, repo, userProps);
+    }
+
+    @Test
+    void testVersionIncrementNone(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "none");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // versionIncrement=none suppresses every kind of increment
+        assertDynamicVersion("1.2.3", source, repo, userProps);
+    }
+
+    @Test
+    void testVersionIncrementEnumOverridesDeprecatedBooleans(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        // the new enum property takes precedence over the deprecated booleans
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
+        userProps.put("nisse.source.jgit.increasePatchVersion", "false");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: a feature");
+
+        // versionIncrement=conventionalCommits wins over increasePatchVersion=false
+        assertDynamicVersion("1.3.0", source, repo, userProps);
+    }
+
+    @Test
+    void testDeprecatedIncreasePatchVersionFalseResolvedAsNone(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        // no versionIncrement set — deprecated boolean is the fallback
+        userProps.put("nisse.source.jgit.increasePatchVersion", "false");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // increasePatchVersion=false without the new property resolves to "none"
+        assertDynamicVersion("1.2.3", source, repo, userProps);
+    }
+
+    @Test
+    void testZeroMajorDemotionDemotesMajorToMinorOnZeroX(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
+        userProps.put("nisse.source.jgit.versionIncrement.zeroMajorDemotion", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "0.5.2");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // with demotion enabled on 0.x: MAJOR -> MINOR, so 0.5.2 -> 0.6.0 (not 1.0.0)
+        assertDynamicVersion("0.6.0", source, repo, userProps);
+    }
+
+    @Test
+    void testZeroMajorDemotionDoesNotAffectNonZeroMajor(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
+        userProps.put("nisse.source.jgit.versionIncrement.zeroMajorDemotion", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.5.2");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // demotion only applies to 0.x; on 1.x a breaking change still bumps major
+        assertDynamicVersion("2.0.0", source, repo, userProps);
+    }
+
+    @Test
+    void testZeroMajorDemotionDisabledKeepsMajorBump(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
+        // explicitly disabled (the default)
+        userProps.put("nisse.source.jgit.versionIncrement.zeroMajorDemotion", "false");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "0.5.2");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // without demotion: plain semver, 0.5.2 -> 1.0.0
+        assertDynamicVersion("1.0.0", source, repo, userProps);
+    }
+
+    @Test
+    void testIncreaseVersionWithZeroMajorDemotion() {
+        // unit-test the increaseVersion method directly for demotion
+        VersionInformation vi;
+
+        // MAJOR on 0.x with demotion -> MINOR
+        vi = new VersionInformation("0.5.2");
+        JGitPropertySource.increaseVersion(vi, JGitPropertySource.Bump.MAJOR, true);
+        assertEquals("0.6.0", vi.toString());
+
+        // MAJOR on 1.x with demotion -> still MAJOR (demotion only applies to 0.x)
+        vi = new VersionInformation("1.5.2");
+        JGitPropertySource.increaseVersion(vi, JGitPropertySource.Bump.MAJOR, true);
+        assertEquals("2.0.0", vi.toString());
+
+        // MINOR on 0.x with demotion -> MINOR (no change, demotion only affects MAJOR)
+        vi = new VersionInformation("0.5.2");
+        JGitPropertySource.increaseVersion(vi, JGitPropertySource.Bump.MINOR, true);
+        assertEquals("0.6.0", vi.toString());
+
+        // MAJOR on 0.x without demotion -> MAJOR
+        vi = new VersionInformation("0.5.2");
+        JGitPropertySource.increaseVersion(vi, JGitPropertySource.Bump.MAJOR, false);
+        assertEquals("1.0.0", vi.toString());
+
+        // MAJOR on 0.x with demotion drops qualifier too
+        vi = new VersionInformation("0.5.2-rc1");
+        JGitPropertySource.increaseVersion(vi, JGitPropertySource.Bump.MAJOR, true);
+        assertEquals("0.6.0", vi.toString());
     }
 
     private static Path newRepo(Path dir) throws Exception {

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.eclipse.aether.version.Version;
+import org.eclipse.jgit.lib.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -1526,6 +1527,109 @@ public class JGitPropertySourceTest {
         vi = new VersionInformation("0.5.2-rc1");
         JGitPropertySource.increaseVersion(vi, JGitPropertySource.Bump.MAJOR, true);
         assertEquals("0.6.0", vi.toString());
+    }
+
+    @Test
+    void testBuildNumberUsesReachabilityCountAcrossMerge(@TempDir Path tempDir) throws Exception {
+        // The build number must use the reachability-based commit count (tag..HEAD), not the
+        // date-ordered walk count, so that commits on a merged branch are counted correctly.
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "conventionalCommits");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+
+        // a branch cut BEFORE the release
+        exec(repo, "git", "checkout", "-b", "side");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat: side feature");
+
+        // the release happens on master afterwards
+        exec(repo, "git", "checkout", "master");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: release");
+        exec(repo, "git", "tag", "1.2.3");
+
+        // ...and only then is the branch merged
+        exec(repo, "git", "merge", "--no-ff", "-m", "chore: merge side", "side");
+
+        // tag..HEAD contains 2 reachable commits: the merge commit and the side feature commit.
+        // With conventionalCommits, the feat: bumps minor -> 1.3.0 and the build number is 2.
+        assertDynamicVersion("1.3.0-2", source, repo, userProps);
+    }
+
+    @Test
+    void testTabAfterColonIsNotAConventionalCommit() {
+        // The specification requires a literal space after the colon; a tab must not match.
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("feat:\ta description"));
+        assertEquals(JGitPropertySource.Bump.PATCH, JGitPropertySource.bumpFrom("fix:\tanother"));
+    }
+
+    @Test
+    void testInvalidVersionIncrementFallsToPatch(@TempDir Path tempDir) throws Exception {
+        // An unknown versionIncrement value should fall back to patch rather than silently doing nothing
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "bogus");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // "bogus" falls back to "patch", so the version increments the patch only
+        assertDynamicVersion("1.2.4", source, repo, userProps);
+    }
+
+    @Test
+    void testWhitespaceVersionIncrementIsTrimmed(@TempDir Path tempDir) throws Exception {
+        // Whitespace around the value should be trimmed and matched case-insensitively
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.versionIncrement", "  None  ");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "feat!: breaking");
+
+        // "  None  " should be trimmed and lowered to "none"
+        assertDynamicVersion("1.2.3", source, repo, userProps);
+    }
+
+    @Test
+    void testSubclassOverrideOfGetVersionFromGitIsRespected(@TempDir Path tempDir) throws Exception {
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.appendBuildNumber", "false");
+        userProps.put("nisse.source.jgit.appendSnapshot", "false");
+
+        // A subclass that overrides the version resolution hook
+        JGitPropertySource source = new JGitPropertySource() {
+            @Override
+            protected GitVersion getVersionFromGit(
+                    Map<String, String> properties,
+                    NisseConfiguration configuration,
+                    org.eclipse.jgit.api.Git git,
+                    ObjectId head) {
+                return new GitVersion(new VersionInformation("9.9.9"), true);
+            }
+        };
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.2.3");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        // The subclass override should be used, not the default git resolution
+        assertDynamicVersion("9.9.9", source, repo, userProps);
     }
 
     private static Path newRepo(Path dir) throws Exception {


### PR DESCRIPTION
## Summary

Adds **Conventional Commits–driven version increment** to the JGit dynamic-version feature.
Instead of always bumping patch, the version increase is now derived from the commit messages since the last version tag, following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

## New configuration properties

### `nisse.source.jgit.versionIncrement`

**Default:** `patch`

Controls how the version is increased when the current commit is not tagged:

| Value | Behaviour | Equivalent deprecated property |
| --- | --- | --- |
| `patch` (default) | Always increase the patch version | `increasePatchVersion=true` |
| `none` | No increase | `increasePatchVersion=false` |
| `conventionalCommits` | Derive from Conventional Commits | _(new)_ |

When set, takes precedence over the deprecated `nisse.source.jgit.increasePatchVersion` and `nisse.source.jgit.conventionalCommits` booleans, which are still honoured as fallbacks when `versionIncrement` is absent. Unknown or empty values log a warning and fall back to `patch`.

### `nisse.source.jgit.versionIncrement.zeroMajorDemotion`

**Default:** `false`

When `true` and the resolved version has a zero major (0.x.y), demotes a MAJOR bump to MINOR. A breaking change on `0.2.3` produces `0.3.0` instead of `1.0.0`, matching the semver convention that 0.x releases are pre-stability.

### Conventional Commits mode

When `versionIncrement=conventionalCommits`, the increase is derived from all commits reachable from HEAD but not from the last version tag. Highest wins:

| Commit | Increase | `1.2.3` becomes |
| --- | --- | --- |
| `fix: ...`, `chore(deps): ...`, or any other type | patch | `1.2.4` |
| `feat: ...`, `feat(lang): ...` | minor, patch reset | `1.3.0` |
| `feat!: ...`, `fix(api)!: ...`, or `BREAKING CHANGE:` footer | major, minor+patch reset | `2.0.0` |

## Key implementation details

- **Reachability-based commit range**: Uses `git.log().add(head).not(tagged)` instead of date-ordered walks, so branches merged after the tag are correctly included in the range
- **Reachability-based build numbers**: `commitCountSince()` uses the same reachability walk for accurate build numbers across merges
- **Input validation**: `resolveVersionIncrement` trims whitespace, normalises case, and warns+falls back to `patch` for unknown values
- **Regex safety**: Conventional Commit subject pattern uses literal space (not `\s`) to avoid matching tab-separated subjects
- **Subclass hook**: `getVersionFromGit` returns `GitVersion` wrapper and delegates to private `resolveVersionFromGit`, preserving the override point for subclasses
- **Deprecated boolean fallback**: Old `increasePatchVersion`/`conventionalCommits` booleans still work when the new `versionIncrement` property is absent
- **Version-hint regression fix**: `GitVersion.isFromReleaseTag` flag replaces the fragile `0.1.0` sentinel comparison, fixing a regression where `0.0.x` + `feat:` → `0.1.0` was misidentified as "no release tag found"

## Backwards compatibility

- Default `versionIncrement=patch` preserves existing behaviour exactly
- Non-conventional-commit messages contribute a patch increase, so enabling this can never increase **less** than `increasePatchVersion` did
- Deprecated boolean properties remain functional as fallbacks

## Also fixed

- **Fallback-empty IT**: Updated `nisse-properties-fallback-empty` integration test in both `extension3-its` and `extension4-its` to match the empty-value guard behaviour from PR #201 / Fix #194 (pre-existing CI failure on main)

## Tests

**62 unit tests pass** (was 57, +5 regression tests for review findings). Coverage includes:

- Message parsing: scopes, `!` marker, both `BREAKING CHANGE` footer spellings, revert bodies, empty scopes
- End-to-end walks: patch → minor → major progression
- Merge scenarios: branch cut before tag, merged after — build number correctness
- Edge cases: `0.0.x` version-hint regression, prerelease qualifiers, no-tag repositories
- Input validation: unknown values, whitespace trimming, empty strings
- Subclass override: anonymous subclass returning custom `GitVersion` is respected by `resolveDynamicVersion`
- Backwards compatibility: disabled mode keeps exact patch behaviour

## Documentation

- `GIT_CONFIGURATION.md` updated with full property reference, examples, and migration guide from deprecated booleans