### PR TITLE
Remove dead putIfAbsent line and add user-props-override ITs (#179)

### DIFF
--- a/extension4/src/main/java/eu/maveniverse/maven/nisse/extension4/internal/NissePropertyContributor.java
+++ b/extension4/src/main/java/eu/maveniverse/maven/nisse/extension4/internal/NissePropertyContributor.java
@@ -61,16 +61,16 @@ final class NissePropertyContributor implements PropertyContributor {
             if (Boolean.parseBoolean(protoSession.getUserProperties().getOrDefault("nisse.dump", "false"))) {
                 nisseProperties.forEach((k, v) -> logger.info("{}={}", k, v));
             }
+            // Override unexpanded placeholders (export-subst $Format:...$, Maven ${...})
+            // from maven-user.properties that Maven 4 auto-loads before extensions run,
+            // but preserve CLI -D overrides for non-placeholder values.
             for (Map.Entry<String, String> entry : nisseProperties.entrySet()) {
                 if (isUnexpandedPlaceholder(result.get(entry.getKey())) && !isUnexpandedPlaceholder(entry.getValue())) {
-                    // we have expanded value
                     result.put(entry.getKey(), entry.getValue());
                 } else {
-                    // otherwise preserve possible user properties precedence (ie CLI -Dnisse.foo.bar=baz)
                     result.putIfAbsent(entry.getKey(), entry.getValue());
                 }
             }
-            nisseProperties.forEach(result::putIfAbsent);
             return result;
         } catch (IOException e) {
             throw new UncheckedIOException("Error while creating Nisse configuration", e);

--- a/it/extension3-its/src/it/user-props-override/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/user-props-override/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/user-props-override/.mvn/maven-user.properties
+++ b/it/extension3-its/src/it/user-props-override/.mvn/maven-user.properties
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Simulates the export-subst scenario: this file contains a stale placeholder.
+# Maven 3 does NOT auto-load maven-user.properties into user properties, so
+# the containsKey guard in extension3 will not find this key and Nisse will
+# inject its computed value normally.
+nisse.file.one=stale-placeholder

--- a/it/extension3-its/src/it/user-props-override/.mvn/maven.config
+++ b/it/extension3-its/src/it/user-props-override/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.file.name=${session.rootDirectory}/build.properties

--- a/it/extension3-its/src/it/user-props-override/build.properties
+++ b/it/extension3-its/src/it/user-props-override/build.properties
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Nisse file source: the computed value that must be injected
+one=fresh-computed

--- a/it/extension3-its/src/it/user-props-override/invoker.properties
+++ b/it/extension3-its/src/it/user-props-override/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = -V help:evaluate -Dexpression=nisse.file.one

--- a/it/extension3-its/src/it/user-props-override/pom.xml
+++ b/it/extension3-its/src/it/user-props-override/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.user-props-override</groupId>
+    <artifactId>user-props-override</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/user-props-override/verify.groovy
+++ b/it/extension3-its/src/it/user-props-override/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verifies that Nisse-computed properties are injected even when
+// .mvn/maven-user.properties exists with a stale value. Maven 3 does NOT
+// auto-load maven-user.properties into user properties, so the containsKey
+// guard in extension3 will not find the key and Nisse injects its computed
+// value normally.
+//
+// We verify via help:evaluate output (the actual merged effective property),
+// not via -Dnisse.dump (which only shows what Nisse computed, not what won).
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+String buildLogText = buildLog.text
+
+// help:evaluate must resolve nisse.file.one to the Nisse-computed value
+assert buildLogText.contains( 'fresh-computed' ) : \
+    'help:evaluate did not resolve nisse.file.one to "fresh-computed"'

--- a/it/extension4-its/src/it/user-props-override/.mvn/extensions.xml
+++ b/it/extension4-its/src/it/user-props-override/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension4</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension4-its/src/it/user-props-override/.mvn/maven-user.properties
+++ b/it/extension4-its/src/it/user-props-override/.mvn/maven-user.properties
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Simulates the export-subst scenario: Maven 4 auto-loads this file before
+# extensions run, pre-populating user properties with unexpanded placeholders.
+# isUnexpandedPlaceholder() recognizes this $Format:..$ pattern and the merge
+# loop overrides it with the Nisse-computed value.
+nisse.file.one=$Format:%(describe:tags=true)$

--- a/it/extension4-its/src/it/user-props-override/.mvn/maven.config
+++ b/it/extension4-its/src/it/user-props-override/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.file.name=${session.rootDirectory}/build.properties

--- a/it/extension4-its/src/it/user-props-override/build.properties
+++ b/it/extension4-its/src/it/user-props-override/build.properties
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# Nisse file source: the computed value that must override the stale
+# placeholder from maven-user.properties
+one=fresh-computed

--- a/it/extension4-its/src/it/user-props-override/invoker.properties
+++ b/it/extension4-its/src/it/user-props-override/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = -V help:evaluate -Dexpression=nisse.file.one

--- a/it/extension4-its/src/it/user-props-override/pom.xml
+++ b/it/extension4-its/src/it/user-props-override/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.nisse.it.user-props-override</groupId>
+    <artifactId>user-props-override</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+</project>

--- a/it/extension4-its/src/it/user-props-override/verify.groovy
+++ b/it/extension4-its/src/it/user-props-override/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verifies that Nisse-computed properties override unexpanded export-subst
+// placeholders pre-loaded from .mvn/maven-user.properties. Maven 4 auto-loads
+// that file before extensions run, populating user properties with the raw
+// $Format:..$ value. The isUnexpandedPlaceholder() check must detect it and
+// the merge loop must override it with the Nisse-computed value.
+//
+// We verify via help:evaluate output (the actual merged effective property),
+// not via -Dnisse.dump (which only shows what Nisse computed, not what won).
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+String buildLogText = buildLog.text
+
+// help:evaluate must resolve nisse.file.one to the Nisse-computed value
+assert buildLogText.contains( 'fresh-computed' ) : \
+    'help:evaluate did not resolve nisse.file.one to "fresh-computed" — placeholder override failed'
+
+// The unexpanded export-subst placeholder must NOT appear as the resolved value
+assert !buildLogText.contains( '%(describe:tags=true)' ) : \
+    'Unexpanded $Format:..$ placeholder from maven-user.properties was not overridden'


### PR DESCRIPTION
## Summary

Follow-up to the fix for #179 (landed in 0.9.7 via 99c113e).

**Code cleanup:**
- Remove the leftover `nisseProperties.forEach(result::putIfAbsent)` line left after the `isUnexpandedPlaceholder` loop was added — every entry is already handled by the loop, so the trailing call is dead code
- Consolidate inline comments into a single block comment above the loop

**Integration tests:**
- `extension4-its/user-props-override` (Maven 4): `.mvn/maven-user.properties` pre-loads a `$Format:..$` export-subst placeholder; verifies the merge loop detects it via `isUnexpandedPlaceholder()` and overrides with the Nisse-computed value from the file source
- `extension3-its/user-props-override` (Maven 3): same fixture, but Maven 3 does not auto-load `maven-user.properties`, so the `containsKey` guard in extension3 injects the computed value normally
- Both ITs assert the `help:evaluate` output (actual effective property), not the `-Dnisse.dump` output (which only shows what Nisse computed internally)

Ref: maveniverse/scalpel#62

## Test plan

- [x] `extension4-its/user-props-override` passes — Nisse overrides `$Format:..$` placeholder
- [x] `extension3-its/user-props-override` passes — Nisse injects normally (no auto-load)
- [x] All existing ITs pass (6/6 extension4, full extension3 suite)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)