### PR TITLE
fix: use committer timezone for nisse.jgit.date

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -506,7 +506,7 @@ public class JGitPropertySource implements PropertySource {
 
         ZonedDateTime commitDateTime = ZonedDateTime.ofInstant(
                 Instant.ofEpochSecond(commit.getCommitTime()),
-                commit.getAuthorIdent().getTimeZone().toZoneId());
+                commit.getCommitterIdent().getTimeZone().toZoneId());
 
         // For ISO-8601 format, convert to UTC
         if ("iso8601".equalsIgnoreCase(dateFormat)) {


### PR DESCRIPTION
## Summary

- Fix `formatCommitDate()` to use committer timezone (`getCommitterIdent().getTimeZone()`) instead of author timezone (`getAuthorIdent().getTimeZone()`)
- The method already uses the committer timestamp via `getCommitTime()`, so the timezone should also come from the committer for consistency
- This matters for rebased/cherry-picked commits where author and committer differ, and makes the `iso8601-offset` format an exact match for git's `%cI` (committer date ISO 8601)

## Test plan

- [x] All existing date format tests pass (default, iso8601, iso8601-offset, custom, invalid-fallback)
- [x] Full `./mvnw clean install -B` passes (all modules including integration tests and Gradle plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit dates now display using the committer’s timezone, improving timestamp accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->