### PR TITLE
Fix #199: reuse single RevWalk for tag reachability checks

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -906,29 +906,39 @@ public class JGitPropertySource implements PropertySource {
         logger.debug("Using version hint regex pattern: {}", hintTagPattern.pattern());
 
         Repository repository = git.getRepository();
-        return git.tagList().call().stream()
-                .filter(tag -> hintTagPattern.matcher(tag.getName()).matches())
-                .filter(tag -> isReachableFrom(repository, tag, head))
-                .map(Ref::getName)
-                .map(hintTagPattern::matcher)
-                .filter(m -> m.matches() && m.groupCount() > 0)
-                .map(m -> m.group(1)) // Extract the version part
-                .collect(Collectors.toList());
+        if (head == null) {
+            // No HEAD — treat all matching tags as reachable
+            return git.tagList().call().stream()
+                    .filter(tag -> hintTagPattern.matcher(tag.getName()).matches())
+                    .map(Ref::getName)
+                    .map(hintTagPattern::matcher)
+                    .filter(m -> m.matches() && m.groupCount() > 0)
+                    .map(m -> m.group(1))
+                    .collect(Collectors.toList());
+        }
+        try (RevWalk revWalk = new RevWalk(repository)) {
+            RevCommit headCommit = revWalk.parseCommit(head);
+            return git.tagList().call().stream()
+                    .filter(tag -> hintTagPattern.matcher(tag.getName()).matches())
+                    .filter(tag -> isReachableFrom(revWalk, repository, tag, headCommit))
+                    .map(Ref::getName)
+                    .map(hintTagPattern::matcher)
+                    .filter(m -> m.matches() && m.groupCount() > 0)
+                    .map(m -> m.group(1)) // Extract the version part
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            logger.debug("Could not open RevWalk for reachability checks: {}", e.getMessage());
+            return Collections.emptyList();
+        }
     }
 
-    private boolean isReachableFrom(Repository repository, Ref tag, ObjectId head) {
-        if (head == null) {
-            return true;
-        }
+    private boolean isReachableFrom(RevWalk revWalk, Repository repository, Ref tag, RevCommit headCommit) {
         try {
             Ref peeledRef = repository.getRefDatabase().peel(tag);
             ObjectId tagObjectId =
                     (peeledRef.getPeeledObjectId() != null ? peeledRef.getPeeledObjectId() : tag.getObjectId());
-            try (RevWalk revWalk = new RevWalk(repository)) {
-                RevCommit tagCommit = revWalk.parseCommit(tagObjectId);
-                RevCommit headCommit = revWalk.parseCommit(head);
-                return revWalk.isMergedInto(tagCommit, headCommit);
-            }
+            RevCommit tagCommit = revWalk.parseCommit(tagObjectId);
+            return revWalk.isMergedInto(tagCommit, headCommit);
         } catch (IOException e) {
             logger.debug("Could not check reachability for tag {}: {}", tag.getName(), e.getMessage());
             return false;

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -666,6 +666,96 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testVersionHintMultipleTags(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // Initial commit with two version hint tags (both reachable from HEAD)
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+        exec(repo, "git", "tag", "-a", "2.0.0-SNAPSHOT", "-m", "hint low");
+        exec(repo, "git", "tag", "-a", "3.0.0-SNAPSHOT", "-m", "hint high");
+
+        // Another commit so HEAD is ahead of the hint tags
+        Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "work");
+
+        // Dynamic version should pick the highest reachable hint: 3.0.0
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> properties = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        String dynamicVersion = properties.get("dynamicVersion");
+        assertNotNull(dynamicVersion, "dynamicVersion should be set");
+        assertTrue(
+                dynamicVersion.startsWith("3.0.0"),
+                "Should use highest reachable hint tag (3.0.0) but got: " + dynamicVersion);
+    }
+
+    @Test
+    void testVersionHintMixedReachability(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // Initial commit — branch point
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+
+        // Create feature branch from this point
+        exec(repo, "git", "branch", "feature");
+
+        // On master: add commit with a high hint tag (unreachable from feature)
+        Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "master work");
+        exec(repo, "git", "tag", "-a", "5.0.0-SNAPSHOT", "-m", "hint on master");
+
+        // Switch to feature: add commit with a lower hint tag (reachable from feature)
+        exec(repo, "git", "checkout", "feature");
+        Files.write(repo.resolve("feat.txt"), "feat".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "feat.txt");
+        exec(repo, "git", "commit", "-m", "feature work");
+        exec(repo, "git", "tag", "-a", "2.0.0-SNAPSHOT", "-m", "hint on feature");
+
+        // Another commit so HEAD is ahead of the hint
+        Files.write(repo.resolve("feat.txt"), "feat2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "feat.txt");
+        exec(repo, "git", "commit", "-m", "more feature work");
+
+        // From feature branch, only the 2.0.0-SNAPSHOT hint should be reachable
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> properties = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        String dynamicVersion = properties.get("dynamicVersion");
+        assertNotNull(dynamicVersion, "dynamicVersion should be set");
+        assertTrue(
+                dynamicVersion.startsWith("2.0.0"),
+                "Should use only reachable hint tag (2.0.0), ignoring unreachable 5.0.0, but got: " + dynamicVersion);
+    }
+
+    @Test
     void testCountingVersion(@TempDir Path tempDir) throws Exception {
         Map<String, String> userProps = new HashMap<>();
         userProps.put("nisse.source.jgit.countingVersion", "true");


### PR DESCRIPTION
## Summary

- Refactors `findVersionHintTags` to create a single `RevWalk` and parse `headCommit` once, then passes both into `isReachableFrom`
- Eliminates per-tag `RevWalk` creation and redundant `head` parsing — reduces O(T) allocations to O(1) for T tags
- Handles `head == null` case early (before opening the `RevWalk`) to preserve existing behavior

## Test plan

- [x] All 34 existing tests pass (including `testVersionHintReachability` which directly exercises the refactored code path)
- [x] Code formatting verified with `mvnw process-sources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version hint resolution when multiple tags are present.
  * Ensured unreachable higher-version tags are ignored in favor of the highest reachable version.
  * Added handling for repositories without a current commit.

* **Tests**
  * Added coverage for multiple reachable version hints.
  * Added coverage for mixed reachable and unreachable version hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->