### PR TITLE
Fix #194: skip empty/blank fallback properties with a clear warning

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManager.java
@@ -94,6 +94,13 @@ public class SimpleNisseManager implements NisseManager {
                 if (isUnexpandedPlaceholder(value)) {
                     skipped++;
                     logger.debug("Skipping unexpanded export-subst placeholder: {}={}", key, value);
+                } else if (value == null || value.trim().isEmpty()) {
+                    skipped++;
+                    logger.warn(
+                            "Skipping empty fallback property '{}' in {} — "
+                                    + "source archives should be created from tagged commits",
+                            key,
+                            nissePropertiesPath);
                 } else {
                     target.put(key, value);
                     loaded++;

--- a/core/src/test/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManagerTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/nisse/core/simple/SimpleNisseManagerTest.java
@@ -177,6 +177,31 @@ public class SimpleNisseManagerTest {
     }
 
     @Test
+    void emptyAndBlankValuesAreSkipped(@TempDir Path tempDir) throws IOException {
+        // Simulate what happens when %(describe:tags=true) expands to empty (no reachable tag)
+        Path mvnDir = tempDir.resolve(".mvn");
+        Files.createDirectories(mvnDir);
+        Properties fallbackProps = new Properties();
+        fallbackProps.setProperty("nisse.jgit.dynamicVersion", "");
+        fallbackProps.setProperty("nisse.jgit.date", "   ");
+        fallbackProps.setProperty("nisse.jgit.commit", "abc123"); // valid value
+        writeProperties(mvnDir.resolve("nisse.properties"), fallbackProps);
+
+        SimpleNisseManager snm = new SimpleNisseManager(Arrays.asList());
+
+        SimpleNisseConfiguration conf = SimpleNisseConfiguration.builder()
+                .withSessionRootDirectory(tempDir)
+                .build();
+
+        Map<String, String> allProperties = snm.createProperties(conf);
+        // empty and blank values should be skipped
+        assertFalse(allProperties.containsKey("nisse.jgit.dynamicVersion"));
+        assertFalse(allProperties.containsKey("nisse.jgit.date"));
+        // valid value should still be loaded
+        assertEquals("abc123", allProperties.get("nisse.jgit.commit"));
+    }
+
+    @Test
     void expandedPlaceholderValuesAreLoaded(@TempDir Path tempDir) throws IOException {
         // Simulate what git archive produces: expanded export-subst values
         Path mvnDir = tempDir.resolve(".mvn");


### PR DESCRIPTION
## Summary

When `%(describe:tags=true)` expands to empty (no reachable tag), the fallback loader in `SimpleNisseManager` now skips the empty/blank property and logs a `WARN`-level message instead of silently passing an empty version to Maven.

### Changes

- **`SimpleNisseManager.loadFallbackProperties`**: added a guard that detects `null`, empty, or blank-only values and skips them with a warning that explains the likely cause ("source archives should be created from tagged commits")
- **`SimpleNisseManagerTest.emptyAndBlankValuesAreSkipped`**: new test verifying that empty (`""`) and blank (`"   "`) fallback values are excluded while valid values are still loaded

Closes #194

## Test plan

- [x] New unit test `emptyAndBlankValuesAreSkipped` covers empty and blank values
- [x] Existing tests still pass (9/9 green)
- [x] Full reactor build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)