### PR TITLE
Fix #195: make TAG_VERSION_PATTERN's tag prefix configurable

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -233,6 +233,16 @@ public class JGitPropertySource implements PropertySource {
     private static final String DEFAULT_VERSION_HINT_PATTERN = "${version}-SNAPSHOT";
 
     /**
+     * Tag prefix for matching version tags. When empty (default), tags starting with an optional
+     * {@code "v"} followed by a semantic version are matched (e.g. {@code v1.0.0}, {@code 2.3.1}).
+     * Set to a non-empty value like {@code "jline-"} or {@code "camel-"} to match prefixed tags
+     * (e.g. {@code jline-3.28.0}, {@code camel-4.8.0}).
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_TAG_PREFIX = "nisse.source.jgit.tagPrefix";
+
+    private static final String DEFAULT_TAG_PREFIX = "";
+
+    /**
      * Configure the timestamp format for the date property. Supports named patterns:
      * - "git" (default): EEE MMM dd HH:mm:ss yyyy Z
      * - "iso8601": yyyy-MM-dd'T'HH:mm:ss'Z' (UTC)
@@ -301,6 +311,23 @@ public class JGitPropertySource implements PropertySource {
     static String redactCredentials(String url) {
         Matcher m = HTTP_CREDENTIAL_PATTERN.matcher(url);
         return m.matches() ? m.group(1) + m.group(2) : url;
+    }
+
+    /**
+     * Builds a tag version pattern based on the configured tag prefix.
+     * <p>
+     * When {@code tagPrefix} is empty, the returned pattern matches the traditional
+     * {@code v?X.Y.Z} form (backward compatible). When non-empty, the prefix is treated
+     * as a literal string (regex-quoted) and replaces the {@code v?} portion.
+     *
+     * @param tagPrefix the tag prefix from configuration, may be {@code null} or empty
+     * @return a compiled pattern for matching version tags
+     */
+    static Pattern buildTagVersionPattern(String tagPrefix) {
+        if (tagPrefix == null || tagPrefix.isEmpty()) {
+            return TAG_VERSION_PATTERN;
+        }
+        return Pattern.compile("refs/tags/" + Pattern.quote(tagPrefix) + "((\\d+\\.\\d+\\.\\d+)(.*))");
     }
 
     @Override
@@ -742,6 +769,22 @@ public class JGitPropertySource implements PropertySource {
             }
             count++;
         }
+
+        // Log when the repository has tags but none matched the version pattern
+        List<Ref> allTags = git.tagList().call();
+        if (!allTags.isEmpty()) {
+            String tagPrefix = configuration
+                    .getConfiguration()
+                    .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_TAG_PREFIX, DEFAULT_TAG_PREFIX);
+            Pattern versionPattern = buildTagVersionPattern(tagPrefix);
+            logger.info(
+                    "Found {} tag(s) but none matched pattern '{}'. Using default version {}."
+                            + " Hint: set nisse.source.jgit.tagPrefix if your tags use a prefix like 'myproject-'.",
+                    allTags.size(),
+                    versionPattern.pattern(),
+                    defaultVersion);
+        }
+
         return mayAddQualifier(properties, configuration, new VersionInformation(defaultVersion + "-" + count));
     }
 
@@ -760,6 +803,10 @@ public class JGitPropertySource implements PropertySource {
                 .getConfiguration()
                 .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_VERSION_HINT_PATTERN, DEFAULT_VERSION_HINT_PATTERN);
         boolean isCustomPattern = !DEFAULT_VERSION_HINT_PATTERN.equals(versionHintPattern);
+
+        String tagPrefix =
+                configuration.getConfiguration().getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_TAG_PREFIX, DEFAULT_TAG_PREFIX);
+        Pattern versionPattern = buildTagVersionPattern(tagPrefix);
 
         return git.tagList().call().stream()
                 .filter(tag -> {
@@ -784,7 +831,7 @@ public class JGitPropertySource implements PropertySource {
                         return !isVersionHintTag(configuration, tagName);
                     }
                 })
-                .map(TAG_VERSION_PATTERN::matcher)
+                .map(versionPattern::matcher)
                 .filter(m -> m.matches() && m.groupCount() > 0)
                 .map(m -> m.group(1))
                 .collect(Collectors.toList());

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -869,6 +869,134 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testBuildTagVersionPatternDefault() {
+        // Empty prefix should return the default TAG_VERSION_PATTERN (v? prefix)
+        Pattern defaultPattern = JGitPropertySource.buildTagVersionPattern("");
+        assertSame(JGitPropertySource.TAG_VERSION_PATTERN, defaultPattern);
+
+        Pattern nullPattern = JGitPropertySource.buildTagVersionPattern(null);
+        assertSame(JGitPropertySource.TAG_VERSION_PATTERN, nullPattern);
+
+        // Default pattern matches v-prefixed and bare version tags
+        assertTrue(defaultPattern.matcher("refs/tags/v1.0.0").matches());
+        assertTrue(defaultPattern.matcher("refs/tags/1.0.0").matches());
+        assertFalse(defaultPattern.matcher("refs/tags/jline-3.28.0").matches());
+        assertFalse(defaultPattern.matcher("refs/tags/release-1.0.0").matches());
+    }
+
+    @Test
+    void testBuildTagVersionPatternCustomPrefix() {
+        Pattern jlinePattern = JGitPropertySource.buildTagVersionPattern("jline-");
+        assertTrue(jlinePattern.matcher("refs/tags/jline-3.28.0").matches());
+        assertFalse(jlinePattern.matcher("refs/tags/v3.28.0").matches());
+        assertFalse(jlinePattern.matcher("refs/tags/3.28.0").matches());
+
+        // Verify version extraction
+        java.util.regex.Matcher m = jlinePattern.matcher("refs/tags/jline-3.28.0");
+        assertTrue(m.matches());
+        assertEquals("3.28.0", m.group(1));
+
+        Pattern releasePattern = JGitPropertySource.buildTagVersionPattern("release-");
+        assertTrue(releasePattern.matcher("refs/tags/release-1.0.0").matches());
+        assertFalse(releasePattern.matcher("refs/tags/v1.0.0").matches());
+
+        Pattern camelPattern = JGitPropertySource.buildTagVersionPattern("camel-");
+        assertTrue(camelPattern.matcher("refs/tags/camel-4.8.0").matches());
+        assertFalse(camelPattern.matcher("refs/tags/v4.8.0").matches());
+    }
+
+    @Test
+    void testBuildTagVersionPatternWithQualifier() {
+        Pattern jlinePattern = JGitPropertySource.buildTagVersionPattern("jline-");
+        java.util.regex.Matcher m = jlinePattern.matcher("refs/tags/jline-3.28.0-rc1");
+        assertTrue(m.matches());
+        assertEquals("3.28.0-rc1", m.group(1));
+        assertEquals("3.28.0", m.group(2));
+        assertEquals("-rc1", m.group(3));
+    }
+
+    @Test
+    void testTagPrefixDynamicVersion(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // Create initial commit with a prefixed tag
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+        exec(repo, "git", "tag", "jline-1.0.0");
+
+        // Create a second commit so version is computed from tag history
+        Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "second commit");
+
+        // Without tagPrefix, the jline- tag is not recognized → falls back to default
+        Map<String, String> propsNoPrefix = new HashMap<>();
+        propsNoPrefix.put("nisse.source.jgit.dynamicVersion", "true");
+
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> resultNoPrefix = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(propsNoPrefix)
+                .build());
+
+        String versionNoPrefix = resultNoPrefix.get("dynamicVersion");
+        assertNotNull(versionNoPrefix, "dynamicVersion should be set");
+        assertTrue(
+                versionNoPrefix.startsWith("0.1.0"),
+                "Without tagPrefix, should fall back to default 0.1.0 but got: " + versionNoPrefix);
+
+        // With tagPrefix=jline-, the tag is recognized
+        Map<String, String> propsWithPrefix = new HashMap<>();
+        propsWithPrefix.put("nisse.source.jgit.dynamicVersion", "true");
+        propsWithPrefix.put("nisse.source.jgit.tagPrefix", "jline-");
+
+        Map<String, String> resultWithPrefix = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(propsWithPrefix)
+                .build());
+
+        String versionWithPrefix = resultWithPrefix.get("dynamicVersion");
+        assertNotNull(versionWithPrefix, "dynamicVersion should be set");
+        assertTrue(
+                versionWithPrefix.startsWith("1.0."),
+                "With tagPrefix=jline-, should resolve from jline-1.0.0 tag but got: " + versionWithPrefix);
+    }
+
+    @Test
+    void testTagPrefixExactMatch(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // Create a commit tagged with the prefixed tag — HEAD is on the tag
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "release");
+        exec(repo, "git", "tag", "mylib-2.5.0");
+
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.tagPrefix", "mylib-");
+
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> result = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        assertEquals("2.5.0", result.get("dynamicVersion"), "Should resolve exact version from tag on HEAD");
+    }
+
+    @Test
     void sanitizeBranchName() {
         assertEquals("master", JGitPropertySource.sanitizeBranchName("master"));
         assertEquals("feat-cool-feature-01", JGitPropertySource.sanitizeBranchName("feat/cool-feature-01"));

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -997,6 +997,64 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testUnmatchedTagsFallbackToDefault(@TempDir Path tempDir) throws Exception {
+        // This test exercises the INFO logging path: tags exist but none match the pattern.
+        // With slf4j-simple we cannot assert on the log message directly, but we verify
+        // the behavioral outcome (fallback to default version) which triggers the log.
+        Path repo = tempDir.resolve("repo");
+        Files.createDirectories(repo);
+
+        exec(repo, "git", "init", "-b", "master");
+        exec(repo, "git", "config", "user.email", "test@test.com");
+        exec(repo, "git", "config", "user.name", "Test");
+
+        // Create commits with tags that use non-standard prefixes
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "initial");
+        exec(repo, "git", "tag", "release-1.0.0");
+
+        Files.write(repo.resolve("file.txt"), "v2".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "second");
+        exec(repo, "git", "tag", "camel-2.0.0");
+
+        Files.write(repo.resolve("file.txt"), "v3".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "third");
+
+        // Default config: neither release- nor camel- tags match → fallback to 0.1.0
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+
+        JGitPropertySource source = new JGitPropertySource();
+        Map<String, String> result = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        String version = result.get("dynamicVersion");
+        assertNotNull(version, "dynamicVersion should be set");
+        assertTrue(
+                version.startsWith("0.1.0"),
+                "Tags exist but none match default pattern, should fall back to 0.1.0 but got: " + version);
+
+        // With tagPrefix=camel-, the camel-2.0.0 tag is recognized
+        userProps.put("nisse.source.jgit.tagPrefix", "camel-");
+
+        result = source.getProperties(SimpleNisseConfiguration.builder()
+                .withCurrentWorkingDirectory(repo)
+                .withUserProperties(userProps)
+                .build());
+
+        version = result.get("dynamicVersion");
+        assertNotNull(version, "dynamicVersion should be set");
+        assertTrue(
+                version.startsWith("2.0."),
+                "With tagPrefix=camel-, should resolve from camel-2.0.0 tag but got: " + version);
+    }
+
+    @Test
     void sanitizeBranchName() {
         assertEquals("master", JGitPropertySource.sanitizeBranchName("master"));
         assertEquals("feat-cool-feature-01", JGitPropertySource.sanitizeBranchName("feat/cool-feature-01"));


### PR DESCRIPTION
## Summary

- Adds `nisse.source.jgit.tagPrefix` property to configure the tag prefix used when matching version tags. Default is empty (preserving the existing `v?` behavior). Setting it to e.g. `jline-` matches tags like `jline-3.28.0`.
- Logs at INFO level when tags exist but none match the configured pattern, with a hint about the `tagPrefix` property. This addresses the silent fallback to `0.1.0` that confused new adopters.
- Adds unit tests for `buildTagVersionPattern()` and integration tests verifying dynamic version resolution with prefixed tags.

## Test plan

- [x] `testBuildTagVersionPatternDefault` — verifies empty/null prefix returns the original `TAG_VERSION_PATTERN`
- [x] `testBuildTagVersionPatternCustomPrefix` — verifies `jline-`, `release-`, `camel-` prefixes match correctly
- [x] `testBuildTagVersionPatternWithQualifier` — verifies qualifier extraction (e.g. `-rc1`) still works with custom prefix
- [x] `testTagPrefixDynamicVersion` — end-to-end: without prefix falls back to `0.1.0`, with `tagPrefix=jline-` resolves from `jline-1.0.0` tag
- [x] `testTagPrefixExactMatch` — HEAD is on a prefixed tag, version resolves exactly
- [x] All 39 existing tests pass (no regressions)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)