### PR TITLE
Fix #198: Use RevWalk with RevSort.REVERSE in countingVersion

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -45,6 +45,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.slf4j.Logger;
@@ -654,30 +655,30 @@ public class JGitPropertySource implements PropertySource {
 
         int commitCount = 0;
 
-        Iterable<RevCommit> commits =
-                head != null ? git.log().add(head).call() : git.log().call();
-        List<RevCommit> all = new ArrayList<>();
-        for (RevCommit c : commits) {
-            all.add(c);
-        }
-        Collections.reverse(all);
-
-        for (RevCommit c : all) {
-            String message = c.getFullMessage();
-            if (message.contains(matchMajor)) {
-                major++;
-                minor = 0;
-                patch = 0;
-                commitCount = 0;
-            } else if (message.contains(matchMinor)) {
-                minor++;
-                patch = 0;
-                commitCount = 0;
-            } else if (message.contains(matchPatch)) {
-                patch++;
-                commitCount = 0;
-            } else {
-                commitCount++;
+        try (RevWalk walk = new RevWalk(git.getRepository())) {
+            walk.sort(RevSort.REVERSE);
+            ObjectId startId = head != null ? head : git.getRepository().resolve("HEAD");
+            if (startId != null) {
+                walk.markStart(walk.parseCommit(startId));
+            }
+            RevCommit c;
+            while ((c = walk.next()) != null) {
+                String message = c.getFullMessage();
+                if (message.contains(matchMajor)) {
+                    major++;
+                    minor = 0;
+                    patch = 0;
+                    commitCount = 0;
+                } else if (message.contains(matchMinor)) {
+                    minor++;
+                    patch = 0;
+                    commitCount = 0;
+                } else if (message.contains(matchPatch)) {
+                    patch++;
+                    commitCount = 0;
+                } else {
+                    commitCount++;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Replaces `ArrayList`-based commit collection and `Collections.reverse()` in `resolveCountingVersion` with JGit's `RevWalk` using `RevSort.REVERSE`
- Commits are now streamed oldest-first directly from the `RevWalk` iterator, eliminating O(N) memory allocation for the full commit history
- Prevents GC pressure and potential OOM on large repositories (e.g. 40k+ commits)

Closes #198

## Test plan

- [x] All 34 existing `JGitPropertySourceTest` tests pass (including 8 counting-version-specific tests)
- [x] Full reactor build passes (`./mvnw clean install -B`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)