### PR TITLE
Fix #196: Add integration tests for .mvn/nisse.properties fallback

### DIFF
--- a/it/extension3-its/src/it/nisse-properties-fallback-empty/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-empty/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/nisse-properties-fallback-empty/.mvn/nisse.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-empty/.mvn/nisse.properties
@@ -1,0 +1,1 @@
+nisse.jgit.dynamicVersion=

--- a/it/extension3-its/src/it/nisse-properties-fallback-empty/invoker.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-empty/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension3-its/src/it/nisse-properties-fallback-empty/pom.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-empty/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-empty</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-empty</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/nisse-properties-fallback-empty/verify.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-empty/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify nisse's current behavior with empty values in .mvn/nisse.properties:
+// an empty string is not an unexpanded placeholder, so it IS loaded as-is.
+// (See maveniverse/nisse#194 for future empty-version-guard discussion.)
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// Empty value should be loaded (not rejected) — nisse treats it as a valid
+// (albeit empty) property value.  The dump line ends with '=' and no value.
+assert logContent.contains('nisse.jgit.dynamicVersion=') :
+    "Empty fallback property nisse.jgit.dynamicVersion should have been loaded"
+
+// The build must succeed (POM uses a hardcoded version, not the empty property)
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension3-its/src/it/nisse-properties-fallback-happy/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-happy/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/nisse-properties-fallback-happy/.mvn/nisse.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-happy/.mvn/nisse.properties
@@ -1,0 +1,1 @@
+nisse.jgit.dynamicVersion=1.2.3-fallback

--- a/it/extension3-its/src/it/nisse-properties-fallback-happy/invoker.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-happy/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension3-its/src/it/nisse-properties-fallback-happy/pom.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-happy/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-happy</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-happy</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/nisse-properties-fallback-happy/verify.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-happy/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify that pre-expanded values from .mvn/nisse.properties are loaded
+// and used as project version (simulates source-archive build without .git).
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// The fallback value should be present in the nisse dump output
+assert logContent.contains('nisse.jgit.dynamicVersion=1.2.3-fallback') :
+    "Fallback property nisse.jgit.dynamicVersion=1.2.3-fallback not found in build log"
+
+// The build must succeed
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/.mvn/maven.config
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.jgit.dynamicVersion=true

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/.mvn/nisse.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/.mvn/nisse.properties
@@ -1,0 +1,1 @@
+nisse.jgit.dynamicVersion=0.0.1-fallback

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/invoker.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/pom.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-priority</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-priority</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/selector.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/selector.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+try {
+    // smoke test if we have a needed tools
+    def gitVersion = "git --version".execute()
+    gitVersion.consumeProcessOutput(System.out, System.out)
+    gitVersion.waitFor()
+    return gitVersion.exitValue() == 0
+} catch (Exception e) {
+    // some error occurs - we skip a test
+    return false
+}

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/setup.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/setup.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+void exec(String[] command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'you@example.com')
+exec('git', 'config', 'user.name', 'Your Name')
+
+exec('git', 'add', 'test.txt')
+exec('git', 'commit', '-m', 'initial-commit')
+exec('git', 'tag', '-a', 'v2.0.0', '-m', 'v2.0.0 as annotated tag')

--- a/it/extension3-its/src/it/nisse-properties-fallback-priority/verify.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-priority/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify that JGit-resolved values take priority over .mvn/nisse.properties
+// fallback values when both are present.
+// - nisse.properties has: nisse.jgit.dynamicVersion=0.0.1-fallback
+// - JGit resolves from git tag v2.0.0: nisse.jgit.dynamicVersion=2.0.0
+// JGit must win.
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// JGit value (from tag v2.0.0) must override the fallback
+assert logContent.contains('nisse.jgit.dynamicVersion=2.0.0') :
+    "JGit-resolved version 2.0.0 should override fallback value"
+
+// The fallback value must NOT be present
+assert !logContent.contains('nisse.jgit.dynamicVersion=0.0.1-fallback') :
+    "Fallback value 0.0.1-fallback should have been overridden by JGit"
+
+// The build must succeed
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/.mvn/nisse.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/.mvn/nisse.properties
@@ -1,0 +1,2 @@
+nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
+nisse.jgit.date=$Format:%cI$

--- a/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/invoker.properties
+++ b/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/pom.xml
+++ b/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-unexpanded</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-unexpanded</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/verify.groovy
+++ b/it/extension3-its/src/it/nisse-properties-fallback-unexpanded/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify that unexpanded git export-subst placeholders ($Format:...$) in
+// .mvn/nisse.properties are rejected and not injected as user properties.
+// This simulates a git checkout (not an archive) where the placeholders
+// have not been expanded.
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// Unexpanded $Format:...$ placeholders must NOT appear in the dump output
+// as injected property values.
+assert !logContent.contains('nisse.jgit.dynamicVersion=$Format:') :
+    "Unexpanded placeholder for nisse.jgit.dynamicVersion should have been skipped"
+assert !logContent.contains('nisse.jgit.date=$Format:') :
+    "Unexpanded placeholder for nisse.jgit.date should have been skipped"
+
+// The build must still succeed (POM uses a hardcoded version, not the missing property)
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension4-its/src/it/nisse-properties-fallback-empty/.mvn/extensions.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-empty/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension4</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension4-its/src/it/nisse-properties-fallback-empty/.mvn/nisse.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-empty/.mvn/nisse.properties
@@ -1,0 +1,1 @@
+nisse.jgit.dynamicVersion=

--- a/it/extension4-its/src/it/nisse-properties-fallback-empty/invoker.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-empty/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension4-its/src/it/nisse-properties-fallback-empty/pom.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-empty/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-empty</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-empty</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension4-its/src/it/nisse-properties-fallback-empty/verify.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-empty/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify nisse's current behavior with empty values in .mvn/nisse.properties:
+// an empty string is not an unexpanded placeholder, so it IS loaded as-is.
+// (See maveniverse/nisse#194 for future empty-version-guard discussion.)
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// Empty value should be loaded (not rejected) — nisse treats it as a valid
+// (albeit empty) property value.  The dump line ends with '=' and no value.
+assert logContent.contains('nisse.jgit.dynamicVersion=') :
+    "Empty fallback property nisse.jgit.dynamicVersion should have been loaded"
+
+// The build must succeed (POM uses a hardcoded version, not the empty property)
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension4-its/src/it/nisse-properties-fallback-happy/.mvn/extensions.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-happy/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension4</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension4-its/src/it/nisse-properties-fallback-happy/.mvn/nisse.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-happy/.mvn/nisse.properties
@@ -1,0 +1,1 @@
+nisse.jgit.dynamicVersion=1.2.3-fallback

--- a/it/extension4-its/src/it/nisse-properties-fallback-happy/invoker.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-happy/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension4-its/src/it/nisse-properties-fallback-happy/pom.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-happy/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-happy</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-happy</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension4-its/src/it/nisse-properties-fallback-happy/verify.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-happy/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify that pre-expanded values from .mvn/nisse.properties are loaded
+// and used as project version (simulates source-archive build without .git).
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// The fallback value should be present in the nisse dump output
+assert logContent.contains('nisse.jgit.dynamicVersion=1.2.3-fallback') :
+    "Fallback property nisse.jgit.dynamicVersion=1.2.3-fallback not found in build log"
+
+// The build must succeed
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/.mvn/extensions.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension4</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/.mvn/maven.config
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/.mvn/maven.config
@@ -1,0 +1,2 @@
+-D
+nisse.source.jgit.dynamicVersion=true

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/.mvn/nisse.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/.mvn/nisse.properties
@@ -1,0 +1,1 @@
+nisse.jgit.dynamicVersion=0.0.1-fallback

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/invoker.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/pom.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-priority</artifactId>
+  <version>${nisse.jgit.dynamicVersion}</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-priority</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/selector.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/selector.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+try {
+    // smoke test if we have a needed tools
+    def gitVersion = "git --version".execute()
+    gitVersion.consumeProcessOutput(System.out, System.out)
+    gitVersion.waitFor()
+    return gitVersion.exitValue() == 0
+} catch (Exception e) {
+    // some error occurs - we skip a test
+    return false
+}

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/setup.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/setup.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+void exec(String[] command) {
+    def proc = command.execute(null, basedir)
+    proc.consumeProcessOutput(System.out, System.out)
+    proc.waitFor()
+    assert proc.exitValue() == 0 : "Command '${command}' returned status: ${proc.exitValue()}"
+}
+
+def testFile = new File(basedir, 'test.txt')
+testFile << 'content'
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'you@example.com')
+exec('git', 'config', 'user.name', 'Your Name')
+
+exec('git', 'add', 'test.txt')
+exec('git', 'commit', '-m', 'initial-commit')
+exec('git', 'tag', '-a', 'v2.0.0', '-m', 'v2.0.0 as annotated tag')

--- a/it/extension4-its/src/it/nisse-properties-fallback-priority/verify.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-priority/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify that JGit-resolved values take priority over .mvn/nisse.properties
+// fallback values when both are present.
+// - nisse.properties has: nisse.jgit.dynamicVersion=0.0.1-fallback
+// - JGit resolves from git tag v2.0.0: nisse.jgit.dynamicVersion=2.0.0
+// JGit must win.
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// JGit value (from tag v2.0.0) must override the fallback
+assert logContent.contains('nisse.jgit.dynamicVersion=2.0.0') :
+    "JGit-resolved version 2.0.0 should override fallback value"
+
+// The fallback value must NOT be present
+assert !logContent.contains('nisse.jgit.dynamicVersion=0.0.1-fallback') :
+    "Fallback value 0.0.1-fallback should have been overridden by JGit"
+
+// The build must succeed
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"

--- a/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/.mvn/extensions.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension4</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/.mvn/nisse.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/.mvn/nisse.properties
@@ -1,0 +1,2 @@
+nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
+nisse.jgit.date=$Format:%cI$

--- a/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/invoker.properties
+++ b/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/invoker.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+invoker.goals = validate -Dnisse.dump

--- a/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/pom.xml
+++ b/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/pom.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>nisse-properties-fallback-unexpanded</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>nisse-properties-fallback-unexpanded</name>
+  <url>http://localhost/</url>
+</project>

--- a/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/verify.groovy
+++ b/it/extension4-its/src/it/nisse-properties-fallback-unexpanded/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Verify that unexpanded git export-subst placeholders ($Format:...$) in
+// .mvn/nisse.properties are rejected and not injected as user properties.
+// This simulates a git checkout (not an archive) where the placeholders
+// have not been expanded.
+
+def mavenLogFile = new File(basedir, 'build.log')
+assert mavenLogFile.exists() : "Maven log file does not exist"
+
+def logContent = mavenLogFile.text
+
+// Unexpanded $Format:...$ placeholders must NOT appear in the dump output
+// as injected property values.
+assert !logContent.contains('nisse.jgit.dynamicVersion=$Format:') :
+    "Unexpanded placeholder for nisse.jgit.dynamicVersion should have been skipped"
+assert !logContent.contains('nisse.jgit.date=$Format:') :
+    "Unexpanded placeholder for nisse.jgit.date should have been skipped"
+
+// The build must still succeed (POM uses a hardcoded version, not the missing property)
+assert logContent.contains('BUILD SUCCESS') : "Build did not succeed"


### PR DESCRIPTION
## Summary

Closes #196. Adds four Maven Invoker Plugin integration tests covering the `.mvn/nisse.properties` fallback mechanism, in **both** `extension3-its` (Maven 3) and `extension4-its` (Maven 4):

- **`nisse-properties-fallback-happy`** — pre-expanded values from `nisse.properties` are loaded and used as `project.version` (simulates a source-archive build without `.git`)
- **`nisse-properties-fallback-unexpanded`** — unexpanded `$Format:…$` placeholders are rejected and not injected as user properties
- **`nisse-properties-fallback-empty`** — empty values are loaded as-is (current behavior; see #194 for future empty-version-guard discussion)
- **`nisse-properties-fallback-priority`** — JGit-resolved values take priority over fallback values when both a git repo and `nisse.properties` are present

## Test plan

- [x] All 4 new `extension3-its` integration tests pass (`Passed: 26, Failed: 0` — no regressions)
- [x] All 4 new `extension4-its` integration tests pass (`Passed: 9, Failed: 0` — no regressions)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)