### PR TITLE
Fix #147: improve documentation and diagnostics for dynamic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ strings from your POM. This works with both Maven 3 and Maven 4.
     <extension>
         <groupId>eu.maveniverse.maven.nisse</groupId>
         <artifactId>extension</artifactId>
-        <version>${version.nisse}</version>
+        <version>0.9.8</version><!-- replace with latest Nisse version -->
     </extension>
 </extensions>
 ```
 
 **2. `.mvn/maven.config`** — enable dynamic versioning:
 
-```
+```text
 -Dnisse.source.jgit.dynamicVersion=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ Nisse is a suite of extensions and plugins for Maven 3 and Maven 4 that provides
 
 ## Usage with Maven
 
-There are 3 extensions: `extension3` meant to be used with Maven 3 exclusively (does not work in Maven 4), then
-`extension4` meant to be used with Maven 4 exclusively (does not work in Maven 3), and finally `extension`, that
-works in both, Maven 3 and Maven 4. Last is the recommended extension to be used. Use it like this:
+There are 3 extension artifacts:
+
+| Artifact | Maven version | Notes |
+|----------|---------------|-------|
+| **`extension`** (recommended) | Maven 3 and Maven 4 | Universal artifact that works in both Maven versions. Use this unless you have a specific reason not to. |
+| `extension3` | Maven 3 only | Does not work in Maven 4. |
+| `extension4` | Maven 4 only | Does not work in Maven 3. |
+
+Add the recommended `extension` artifact to `.mvn/extensions.xml`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -44,6 +50,61 @@ The `-N` is needed only if you are in root of some complex multi-module project.
 Note that this only works when Nisse is declared as a ["core extension"](https://maven.apache.org/guides/mini/guide-using-extensions.html) 
 (Maven 3 and 4) through **.mvn/extensions.xml** or as a "user-wide extension" (Maven 4 only) through **~/.m2/extensions.xml**.
 Otherwise, one may use `dump-properties` Mojo or the `nisse.dump` property of `inject-properties` Mojo. 
+
+### Quick Start: Git-based dynamic versioning
+
+Nisse can derive your project version from Git tags automatically, eliminating hardcoded version
+strings from your POM. This works with both Maven 3 and Maven 4.
+
+**1. `.mvn/extensions.xml`** — register Nisse as a core extension:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension</artifactId>
+        <version>${version.nisse}</version>
+    </extension>
+</extensions>
+```
+
+**2. `.mvn/maven.config`** — enable dynamic versioning:
+
+```
+-Dnisse.source.jgit.dynamicVersion=true
+```
+
+**3. `pom.xml`** — use the dynamic version property:
+
+```xml
+<version>${nisse.jgit.dynamicVersion}</version>
+```
+
+That's it. Nisse will compute the version from your Git history (tags, commits, branch) and inject
+it at build time. Run `mvn validate -N -Dnisse.dump` to see the resolved value.
+
+#### Using translation to map to `${revision}` (CI Friendly Versions)
+
+If you prefer to use Maven's standard `${revision}` property (for example, to keep compatibility
+with tools that expect CI Friendly Versions), add a translation file:
+
+**`.mvn/nisse-translation.properties`:**
+
+```properties
+jgit.dynamicVersion=revision
+```
+
+This translates the Nisse key so the version is published as `${revision}` instead of
+`${nisse.jgit.dynamicVersion}`. Your POM then uses:
+
+```xml
+<version>${revision}</version>
+```
+
+> **Note:** When using translation, make sure the POM references the *translated* property name
+> (`${revision}`), not the original (`${nisse.jgit.dynamicVersion}`). Nisse will warn you if a
+> translated property is still referenced by its original name.
 
 ## Usage with Gradle
 

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
@@ -64,15 +64,16 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
                 List<String> translatedTo = table.get(sourcePrefixedKey);
                 if (translatedTo != null) {
                     List<String> targets = translatedTo.stream()
+                            .map(String::trim)
                             .filter(k -> !"+fallback".equals(k))
                             .collect(Collectors.toList());
                     if (!targets.isEmpty()) {
                         String targetExprs =
                                 targets.stream().map(k -> "${" + k + "}").collect(Collectors.joining(", "));
                         logger.warn(
-                                "POM references ${{{}}}, but this property was translated to {} via "
+                                "POM references {}, but this property was translated to {} via "
                                         + "nisse-translation.properties. Use {} instead, or remove the translation.",
-                                property,
+                                "${" + property + "}",
                                 targetExprs,
                                 targetExprs);
                     }

--- a/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/nisse/extension3/internal/NisseModelVersionProcessor.java
@@ -10,7 +10,13 @@ package eu.maveniverse.maven.nisse.extension3.internal;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.nisse.core.NisseConfiguration;
+import eu.maveniverse.maven.nisse.core.PropertyKeyNamingStrategies;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -29,6 +35,7 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
     private final Logger logger = LoggerFactory.getLogger(NisseModelVersionProcessor.class);
     private final Provider<MavenSession> sessionProvider;
     private final NissePropertyInliner inliner;
+    private volatile Map<String, List<String>> translationTable;
 
     @Inject
     public NisseModelVersionProcessor(Provider<MavenSession> sessionProvider, NissePropertyInliner inliner) {
@@ -43,8 +50,53 @@ final class NisseModelVersionProcessor implements ModelVersionProcessor {
                 && session.getRequest().getUserProperties().containsKey(property);
         if (valid) {
             inliner.inlinedKeys(session).add(property);
+        } else if (property.startsWith(NisseConfiguration.PROPERTY_PREFIX)) {
+            warnIfTranslated(session, property);
         }
         return valid;
+    }
+
+    private void warnIfTranslated(MavenSession session, String property) {
+        try {
+            Map<String, List<String>> table = loadTranslationTable(session);
+            if (!table.isEmpty()) {
+                String sourcePrefixedKey = property.substring(NisseConfiguration.PROPERTY_PREFIX.length());
+                List<String> translatedTo = table.get(sourcePrefixedKey);
+                if (translatedTo != null) {
+                    List<String> targets = translatedTo.stream()
+                            .filter(k -> !"+fallback".equals(k))
+                            .collect(Collectors.toList());
+                    if (!targets.isEmpty()) {
+                        String targetExprs =
+                                targets.stream().map(k -> "${" + k + "}").collect(Collectors.joining(", "));
+                        logger.warn(
+                                "POM references ${{{}}}, but this property was translated to {} via "
+                                        + "nisse-translation.properties. Use {} instead, or remove the translation.",
+                                property,
+                                targetExprs,
+                                targetExprs);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to check translation table: {}", e.getMessage());
+        }
+    }
+
+    private Map<String, List<String>> loadTranslationTable(MavenSession session) throws IOException {
+        if (translationTable == null) {
+            synchronized (this) {
+                if (translationTable == null) {
+                    Path translationFile = session.getRequest()
+                            .getMultiModuleProjectDirectory()
+                            .toPath()
+                            .resolve(".mvn")
+                            .resolve("nisse-translation.properties");
+                    translationTable = PropertyKeyNamingStrategies.translationTableFromPropertiesFile(translationFile);
+                }
+            }
+        }
+        return translationTable;
     }
 
     @Override


### PR DESCRIPTION
## Summary

- **Warn on translated property references**: When `nisse-translation.properties` remaps a property (e.g. `jgit.dynamicVersion=revision`), but the POM still references the original `${nisse.jgit.dynamicVersion}`, Nisse now logs a clear warning pointing the user to the correct translated property name. Previously, Maven would only show a generic `'version' must be a constant version` error.

- **Clarify extension artifact selection**: Replaced the prose paragraph about `extension` / `extension3` / `extension4` with a comparison table, making it immediately obvious which artifact to use (the universal `extension` is recommended).

- **Add complete Quick Start guide**: Added a step-by-step guide for Git-based dynamic versioning with Maven, including the extensions.xml, maven.config, and pom.xml setup. Also documents the translation-to-`${revision}` workflow for CI Friendly Versions.

## Test plan

- [x] Full project build passes (`mvn clean install -B`)
- [ ] Verify CI passes
- [ ] Manual verification: configure a project with `nisse-translation.properties` mapping `jgit.dynamicVersion=revision` but keep `${nisse.jgit.dynamicVersion}` in POM — verify the warning appears

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Git-based dynamic versioning quick-start guidance for Maven 3 and 4.
  - Added configuration examples, extension registration steps, POM usage, and optional `${revision}` translation guidance.
  - Added warnings that suggest translated property expressions when an invalid prefixed property has available alternatives.

- **Documentation**
  - Updated Maven usage documentation with a comparison of the three extension artifacts.
  - Recommended the universal `extension` artifact and refreshed setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->