### PR TITLE
Fix #197: Add named presets for dynamicVersion configuration

### DIFF
--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/DynamicVersionPreset.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/DynamicVersionPreset.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.nisse.source.jgit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Named presets for dynamic version configuration. Each preset provides sensible defaults
+ * for the individual dynamic version properties, reducing configuration from multiple
+ * boolean/string properties down to a single property.
+ * <p>
+ * Individual properties always override preset defaults, so the full flexibility is
+ * preserved for advanced users.
+ *
+ * @see JGitPropertySource
+ */
+enum DynamicVersionPreset {
+
+    /**
+     * Development builds (current default behavior): increment patch, append build number, append SNAPSHOT.
+     */
+    SNAPSHOT,
+
+    /**
+     * CI builds: increment patch, append build number, append branch name, no SNAPSHOT.
+     */
+    CI,
+
+    /**
+     * Release builds: exact tag version, no increment, no qualifiers.
+     */
+    RELEASE,
+
+    /**
+     * Local development: like snapshot, plus append DIRTY qualifier on uncommitted changes.
+     */
+    DIRTY;
+
+    private static final String INCREASE_PATCH_VERSION = "nisse.source.jgit.increasePatchVersion";
+    private static final String VERSION_INCREMENT = "nisse.source.jgit.versionIncrement";
+    private static final String APPEND_BUILD_NUMBER = "nisse.source.jgit.appendBuildNumber";
+    private static final String APPEND_SNAPSHOT = "nisse.source.jgit.appendSnapshot";
+    private static final String APPEND_BRANCH_NAME = "nisse.source.jgit.appendBranchName";
+    private static final String APPEND_DIRTY = "nisse.source.jgit.appendDirty";
+
+    /**
+     * Returns the default property values for this preset.
+     *
+     * @return an unmodifiable map of property keys to their default values
+     */
+    Map<String, String> defaults() {
+        Map<String, String> map = new HashMap<>();
+        switch (this) {
+            case SNAPSHOT:
+                map.put(INCREASE_PATCH_VERSION, Boolean.TRUE.toString());
+                map.put(APPEND_BUILD_NUMBER, Boolean.TRUE.toString());
+                map.put(APPEND_SNAPSHOT, Boolean.TRUE.toString());
+                map.put(APPEND_BRANCH_NAME, Boolean.FALSE.toString());
+                map.put(APPEND_DIRTY, Boolean.FALSE.toString());
+                break;
+            case CI:
+                map.put(INCREASE_PATCH_VERSION, Boolean.TRUE.toString());
+                map.put(APPEND_BUILD_NUMBER, Boolean.TRUE.toString());
+                map.put(APPEND_SNAPSHOT, Boolean.FALSE.toString());
+                map.put(APPEND_BRANCH_NAME, Boolean.TRUE.toString());
+                map.put(APPEND_DIRTY, Boolean.FALSE.toString());
+                break;
+            case RELEASE:
+                map.put(VERSION_INCREMENT, "none");
+                map.put(APPEND_BUILD_NUMBER, Boolean.FALSE.toString());
+                map.put(APPEND_SNAPSHOT, Boolean.FALSE.toString());
+                map.put(APPEND_BRANCH_NAME, Boolean.FALSE.toString());
+                map.put(APPEND_DIRTY, Boolean.FALSE.toString());
+                break;
+            case DIRTY:
+                map.put(INCREASE_PATCH_VERSION, Boolean.TRUE.toString());
+                map.put(APPEND_BUILD_NUMBER, Boolean.TRUE.toString());
+                map.put(APPEND_SNAPSHOT, Boolean.TRUE.toString());
+                map.put(APPEND_BRANCH_NAME, Boolean.FALSE.toString());
+                map.put(APPEND_DIRTY, Boolean.TRUE.toString());
+                break;
+            default:
+                break;
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Parses a preset name (case-insensitive, trimmed). Returns {@code null} for unknown values.
+     *
+     * @param name the preset name to parse
+     * @return the matching preset, or {@code null} if the name is {@code null}, empty, or unknown
+     */
+    static DynamicVersionPreset fromString(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return valueOf(name.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
+++ b/sources/jgit-source/src/main/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySource.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -101,6 +102,17 @@ public class JGitPropertySource implements PropertySource {
     private static final String JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION = "nisse.source.jgit.dynamicVersion";
 
     private static final String DEFAULT_DYNAMIC_VERSION = Boolean.FALSE.toString();
+
+    /**
+     * Named preset for dynamic version configuration. Sets sensible defaults for all dynamic version
+     * properties at once. Individual properties always override the preset.
+     * <p>
+     * Known presets: {@code snapshot} (default behavior), {@code ci}, {@code release}, {@code dirty}.
+     *
+     * @see DynamicVersionPreset
+     */
+    private static final String JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION_PRESET =
+            "nisse.source.jgit.dynamicVersion.preset";
 
     /**
      * Set to {@code true} to enable "counting version" feature, it adds the
@@ -460,7 +472,9 @@ public class JGitPropertySource implements PropertySource {
                     if (Boolean.parseBoolean(configuration
                             .getConfiguration()
                             .getOrDefault(JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION, DEFAULT_DYNAMIC_VERSION))) {
-                        result.put(JGIT_DYNAMIC_VERSION, resolveDynamicVersion(result, configuration, git, head));
+                        NisseConfiguration effectiveConfiguration = applyPresetDefaults(configuration);
+                        result.put(
+                                JGIT_DYNAMIC_VERSION, resolveDynamicVersion(result, effectiveConfiguration, git, head));
                     }
                     if (Boolean.parseBoolean(configuration
                             .getConfiguration()
@@ -638,6 +652,79 @@ public class JGitPropertySource implements PropertySource {
                         dateFormat);
                 return DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss yyyy Z", Locale.ENGLISH);
         }
+    }
+
+    /**
+     * If a {@link DynamicVersionPreset} is configured, returns a configuration whose
+     * {@link NisseConfiguration#getConfiguration()} map contains the preset's defaults
+     * for any dynamic-version property not explicitly set by the user. When no preset
+     * is configured, the original configuration is returned unchanged.
+     *
+     * @param configuration the original configuration
+     * @return the effective configuration (may be a delegate wrapping the original)
+     */
+    NisseConfiguration applyPresetDefaults(NisseConfiguration configuration) {
+        String presetName = configuration.getConfiguration().get(JGIT_CONF_SYSTEM_PROPERTY_DYNAMIC_VERSION_PRESET);
+        if (presetName == null) {
+            return configuration;
+        }
+        DynamicVersionPreset preset = DynamicVersionPreset.fromString(presetName);
+        if (preset == null) {
+            logger.warn(
+                    "Unknown dynamicVersion preset '{}', ignoring. Known presets: snapshot, ci, release, dirty",
+                    presetName);
+            return configuration;
+        }
+
+        logger.debug("Applying dynamicVersion preset '{}'", preset.name().toLowerCase(Locale.ROOT));
+        Map<String, String> presetDefaults = preset.defaults();
+        Map<String, String> effectiveConfig = new HashMap<>(configuration.getConfiguration());
+        for (Map.Entry<String, String> entry : presetDefaults.entrySet()) {
+            effectiveConfig.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+        Map<String, String> unmodifiableConfig = Collections.unmodifiableMap(effectiveConfig);
+
+        return new NisseConfiguration() {
+            @Override
+            public Map<String, String> getSystemProperties() {
+                return configuration.getSystemProperties();
+            }
+
+            @Override
+            public Map<String, String> getUserProperties() {
+                return configuration.getUserProperties();
+            }
+
+            @Override
+            public Map<String, String> getConfiguration() {
+                return unmodifiableConfig;
+            }
+
+            @Override
+            public Path getCurrentWorkingDirectory() {
+                return configuration.getCurrentWorkingDirectory();
+            }
+
+            @Override
+            public Path getSessionRootDirectory() {
+                return configuration.getSessionRootDirectory();
+            }
+
+            @Override
+            public boolean isPropertySourceActive(PropertySource source) {
+                return configuration.isPropertySourceActive(source);
+            }
+
+            @Override
+            public Collection<String> getInlinedPropertyKeys() {
+                return configuration.getInlinedPropertyKeys();
+            }
+
+            @Override
+            public BiFunction<PropertySource, String, List<String>> propertyKeyNamingStrategy() {
+                return configuration.propertyKeyNamingStrategy();
+            }
+        };
     }
 
     String resolveDynamicVersion(

--- a/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
+++ b/sources/jgit-source/src/test/java/eu/maveniverse/maven/nisse/source/jgit/JGitPropertySourceTest.java
@@ -1147,6 +1147,192 @@ public class JGitPropertySourceTest {
     }
 
     @Test
+    void testPresetSnapshot(@TempDir Path tempDir) throws Exception {
+        // Snapshot preset: increment patch, append build number, append SNAPSHOT, no branch, no dirty
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "snapshot");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        assertDynamicVersion("1.0.1-1-SNAPSHOT", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetCi(@TempDir Path tempDir) throws Exception {
+        // CI preset: increment patch, append build number, append branch name, no SNAPSHOT
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "ci");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        assertDynamicVersion("1.0.1-1-master", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetRelease(@TempDir Path tempDir) throws Exception {
+        // Release preset: exact tag version, no increment, no qualifiers
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "release");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+
+        // On the tag itself: exact version
+        assertDynamicVersion("1.0.0", source, repo, userProps);
+
+        // Even after additional commits: no increment (versionIncrement=none), no qualifiers
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+        assertDynamicVersion("1.0.0", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetDirtyClean(@TempDir Path tempDir) throws Exception {
+        // Dirty preset on a clean repo: like snapshot, no DIRTY qualifier
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "dirty");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        // Clean repo: same as snapshot (no DIRTY qualifier)
+        assertDynamicVersion("1.0.1-1-SNAPSHOT", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetDirtyUncommitted(@TempDir Path tempDir) throws Exception {
+        // Dirty preset with uncommitted changes: like snapshot + DIRTY qualifier
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "dirty");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        Files.write(repo.resolve("file.txt"), "v1".getBytes(StandardCharsets.UTF_8));
+        exec(repo, "git", "add", "file.txt");
+        exec(repo, "git", "commit", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        // Create uncommitted changes
+        Files.write(repo.resolve("file.txt"), "dirty".getBytes(StandardCharsets.UTF_8));
+
+        assertDynamicVersion("1.0.1-1-DIRTY-SNAPSHOT", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetOverriddenByExplicitProperty(@TempDir Path tempDir) throws Exception {
+        // Explicit properties override preset defaults
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "ci");
+        // Override: disable branch name even though ci preset enables it
+        userProps.put("nisse.source.jgit.appendBranchName", "false");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        // CI preset would add branch name, but the explicit override disables it
+        assertDynamicVersion("1.0.1-1", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetCaseInsensitive(@TempDir Path tempDir) throws Exception {
+        // Preset name should be case-insensitive
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "RELEASE");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "2.0.0");
+
+        assertDynamicVersion("2.0.0", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetUnknownIgnored(@TempDir Path tempDir) throws Exception {
+        // Unknown preset name should be ignored (fall back to default behavior)
+        Map<String, String> userProps = new HashMap<>();
+        userProps.put("nisse.source.jgit.dynamicVersion", "true");
+        userProps.put("nisse.source.jgit.dynamicVersion.preset", "bogus");
+        JGitPropertySource source = new JGitPropertySource();
+
+        Path repo = newRepo(tempDir);
+        exec(repo, "git", "commit", "--allow-empty", "-m", "chore: base");
+        exec(repo, "git", "tag", "1.0.0");
+        exec(repo, "git", "commit", "--allow-empty", "-m", "fix: a bug");
+
+        // Should behave as if no preset was set (default behavior = snapshot-like)
+        assertDynamicVersion("1.0.1-1-SNAPSHOT", source, repo, userProps);
+    }
+
+    @Test
+    void testPresetFromString() {
+        assertEquals(DynamicVersionPreset.SNAPSHOT, DynamicVersionPreset.fromString("snapshot"));
+        assertEquals(DynamicVersionPreset.CI, DynamicVersionPreset.fromString("ci"));
+        assertEquals(DynamicVersionPreset.RELEASE, DynamicVersionPreset.fromString("release"));
+        assertEquals(DynamicVersionPreset.DIRTY, DynamicVersionPreset.fromString("dirty"));
+        assertEquals(DynamicVersionPreset.SNAPSHOT, DynamicVersionPreset.fromString("SNAPSHOT"));
+        assertEquals(DynamicVersionPreset.CI, DynamicVersionPreset.fromString("  CI  "));
+        assertNull(DynamicVersionPreset.fromString("bogus"));
+        assertNull(DynamicVersionPreset.fromString(""));
+        assertNull(DynamicVersionPreset.fromString(null));
+    }
+
+    @Test
+    void testPresetDefaults() {
+        // Verify each preset returns the expected default values
+        Map<String, String> snapshot = DynamicVersionPreset.SNAPSHOT.defaults();
+        assertEquals("true", snapshot.get("nisse.source.jgit.increasePatchVersion"));
+        assertEquals("true", snapshot.get("nisse.source.jgit.appendBuildNumber"));
+        assertEquals("true", snapshot.get("nisse.source.jgit.appendSnapshot"));
+        assertEquals("false", snapshot.get("nisse.source.jgit.appendBranchName"));
+        assertEquals("false", snapshot.get("nisse.source.jgit.appendDirty"));
+
+        Map<String, String> ci = DynamicVersionPreset.CI.defaults();
+        assertEquals("true", ci.get("nisse.source.jgit.increasePatchVersion"));
+        assertEquals("true", ci.get("nisse.source.jgit.appendBuildNumber"));
+        assertEquals("false", ci.get("nisse.source.jgit.appendSnapshot"));
+        assertEquals("true", ci.get("nisse.source.jgit.appendBranchName"));
+        assertEquals("false", ci.get("nisse.source.jgit.appendDirty"));
+
+        Map<String, String> release = DynamicVersionPreset.RELEASE.defaults();
+        assertEquals("none", release.get("nisse.source.jgit.versionIncrement"));
+        assertEquals("false", release.get("nisse.source.jgit.appendBuildNumber"));
+        assertEquals("false", release.get("nisse.source.jgit.appendSnapshot"));
+        assertEquals("false", release.get("nisse.source.jgit.appendBranchName"));
+        assertEquals("false", release.get("nisse.source.jgit.appendDirty"));
+
+        Map<String, String> dirty = DynamicVersionPreset.DIRTY.defaults();
+        assertEquals("true", dirty.get("nisse.source.jgit.increasePatchVersion"));
+        assertEquals("true", dirty.get("nisse.source.jgit.appendBuildNumber"));
+        assertEquals("true", dirty.get("nisse.source.jgit.appendSnapshot"));
+        assertEquals("false", dirty.get("nisse.source.jgit.appendBranchName"));
+        assertEquals("true", dirty.get("nisse.source.jgit.appendDirty"));
+    }
+
+    @Test
     void sanitizeBranchName() {
         assertEquals("master", JGitPropertySource.sanitizeBranchName("master"));
         assertEquals("feat-cool-feature-01", JGitPropertySource.sanitizeBranchName("feat/cool-feature-01"));


### PR DESCRIPTION
## Summary

- Adds a `nisse.source.jgit.dynamicVersion.preset` property with four named presets (`snapshot`, `ci`, `release`, `dirty`) that set sensible defaults for all dynamic version properties at once
- Individual properties always override preset defaults, preserving full flexibility for advanced users
- Includes a new `DynamicVersionPreset` enum and integration into `JGitPropertySource` via configuration overlay

### Presets

| Preset | Behavior | Typical use |
|--------|----------|-------------|
| `snapshot` | increment patch, append build number, append SNAPSHOT | Development builds |
| `ci` | increment patch, append build number, append branch name, no SNAPSHOT | CI builds |
| `release` | exact tag version, no increment, no qualifiers | Release builds |
| `dirty` | like snapshot + append DIRTY qualifier on uncommitted changes | Local dev |

### Example

Before (`.mvn/maven.config`):
```
-Dnisse.source.jgit.dynamicVersion=true
-Dnisse.source.jgit.appendBranchName=true
-Dnisse.source.jgit.appendSnapshot=false
```

After:
```
-Dnisse.source.jgit.dynamicVersion=true
-Dnisse.source.jgit.dynamicVersion.preset=ci
```

## Test plan

- [x] Unit tests for `DynamicVersionPreset.fromString()` parsing (case-insensitive, trimming, null handling)
- [x] Unit tests for `DynamicVersionPreset.defaults()` verifying each preset's default values
- [x] Integration tests for each preset (`snapshot`, `ci`, `release`, `dirty`) using real git repos
- [x] Test that explicit properties override preset defaults
- [x] Test that unknown preset names are ignored with a warning
- [x] Test dirty preset with both clean and dirty repos
- [x] Full reactor build passes
- [x] All 72 existing + new tests pass

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)